### PR TITLE
Trace listener abstraction

### DIFF
--- a/src/SQLite.Net/DebugTraceListener.cs
+++ b/src/SQLite.Net/DebugTraceListener.cs
@@ -1,0 +1,18 @@
+﻿using System.Diagnostics;
+
+namespace SQLite.Net
+{
+    public sealed class DebugTraceListener : ITraceListener
+    {
+        public static DebugTraceListener Instance = new DebugTraceListener();
+
+        private DebugTraceListener()
+        {
+        }
+            
+        public void Receive(string message)
+        {
+            Debug.WriteLine(message);
+        }
+    }
+}

--- a/src/SQLite.Net/ITraceListener.cs
+++ b/src/SQLite.Net/ITraceListener.cs
@@ -1,0 +1,7 @@
+﻿namespace SQLite.Net
+{
+    public interface ITraceListener
+    {
+        void Receive(string message);
+    }
+}

--- a/src/SQLite.Net/PreparedSqlLiteInsertCommand.cs
+++ b/src/SQLite.Net/PreparedSqlLiteInsertCommand.cs
@@ -57,10 +57,7 @@ namespace SQLite.Net
 
         public int ExecuteNonQuery(object[] source)
         {
-            if (Connection.Trace)
-            {
-                Debug.WriteLine("Executing: " + CommandText);
-            }
+            Connection.TraceListener.WriteLine("Executing: {0}", CommandText);
 
             var r = Result.OK;
 

--- a/src/SQLite.Net/SQLite.Net.csproj
+++ b/src/SQLite.Net/SQLite.Net.csproj
@@ -35,6 +35,8 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <ProductVersion>12.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -97,6 +99,9 @@
     <Compile Include="Interop\SQLiteOpenFlags.cs" />
     <Compile Include="Attributes\TableAttribute.cs" />
     <Compile Include="Attributes\UniqueAttribute.cs" />
+    <Compile Include="ITraceListener.cs" />
+    <Compile Include="TraceListenerExtensions.cs" />
+    <Compile Include="DebugTraceListener.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/src/SQLite.Net/SQLiteCommand.cs
+++ b/src/SQLite.Net/SQLiteCommand.cs
@@ -48,10 +48,7 @@ namespace SQLite.Net
 
         public int ExecuteNonQuery()
         {
-            if (_conn.Trace)
-            {
-                Debug.WriteLine("Executing: " + this);
-            }
+            _conn.TraceListener.WriteLine("Executing: {0}", this);
 
             var r = Result.OK;
             IDbStatement stmt = Prepare();
@@ -103,10 +100,7 @@ namespace SQLite.Net
 
         public IEnumerable<T> ExecuteDeferredQuery<T>(TableMapping map)
         {
-            if (_conn.Trace)
-            {
-                Debug.WriteLine("Executing Query: " + this);
-            }
+            _conn.TraceListener.WriteLine("Executing Query: {0}", this);
 
             IDbStatement stmt = Prepare();
             try
@@ -144,10 +138,7 @@ namespace SQLite.Net
 
         public T ExecuteScalar<T>()
         {
-            if (_conn.Trace)
-            {
-                Debug.WriteLine("Executing Query: " + this);
-            }
+            _conn.TraceListener.WriteLine("Executing Query: {0}", this);
 
             T val = default(T);
 

--- a/src/SQLite.Net/SQLiteConnection.cs
+++ b/src/SQLite.Net/SQLiteConnection.cs
@@ -138,7 +138,7 @@ namespace SQLite.Net
 
         public bool TimeExecution { get; set; }
 
-        public bool Trace { get; set; }
+        public ITraceListener TraceListener { get; set; }
 
         public bool StoreDateTimeAsTicks { get; private set; }
 
@@ -521,8 +521,8 @@ namespace SQLite.Net
             {
                 _sw.Stop();
                 _elapsedMilliseconds += _sw.ElapsedMilliseconds;
-                Debug.WriteLine("Finished in {0} ms ({1:0.0} s total)", _sw.ElapsedMilliseconds,
-                    _elapsedMilliseconds/1000.0);
+
+                this.TraceListener.WriteLine("Finished in {0} ms ({1:0.0} s total)", _sw.ElapsedMilliseconds, _elapsedMilliseconds / 1000.0);
             }
 
             return r;
@@ -548,8 +548,8 @@ namespace SQLite.Net
             {
                 _sw.Stop();
                 _elapsedMilliseconds += _sw.ElapsedMilliseconds;
-                Debug.WriteLine("Finished in {0} ms ({1:0.0} s total)", _sw.ElapsedMilliseconds,
-                    _elapsedMilliseconds/1000.0);
+
+                this.TraceListener.WriteLine("Finished in {0} ms ({1:0.0} s total)", _sw.ElapsedMilliseconds, _elapsedMilliseconds / 1000.0);
             }
 
             return r;

--- a/src/SQLite.Net/TraceListenerExtensions.cs
+++ b/src/SQLite.Net/TraceListenerExtensions.cs
@@ -1,0 +1,47 @@
+﻿using System.Globalization;
+
+namespace SQLite.Net
+{
+    public static class TraceListenerExtensions
+    {
+        public static void WriteLine(this ITraceListener @this, string message)
+        {
+            if (@this == null)
+            {
+                return;
+            }
+
+            @this.Receive(message);
+        }
+
+        public static void WriteLine(this ITraceListener @this, string format, object arg1)
+        {
+            if (@this == null)
+            {
+                return;
+            }
+
+            @this.Receive(string.Format(CultureInfo.InvariantCulture, format, arg1));
+        }
+
+        public static void WriteLine(this ITraceListener @this, string format, object arg1, object arg2)
+        {
+            if (@this == null)
+            {
+                return;
+            }
+
+            @this.Receive(string.Format(CultureInfo.InvariantCulture, format, arg1, arg2));
+        }
+
+        public static void WriteLine(this ITraceListener @this, string format, params object[] args)
+        {
+            if (@this == null)
+            {
+                return;
+            }
+
+            @this.Receive(string.Format(CultureInfo.InvariantCulture, format, args));
+        }
+    }
+}

--- a/tests/BooleanTest.cs
+++ b/tests/BooleanTest.cs
@@ -40,7 +40,7 @@ namespace SQLite.Net.Tests
             public DbAcs(ISQLitePlatform sqlitePlatform, String path)
                 : base(sqlitePlatform, path)
             {
-                Trace = true;
+                TraceListener = DebugTraceListener.Instance;
             }
 
             public void buildTable()

--- a/tests/CollateTest.cs
+++ b/tests/CollateTest.cs
@@ -47,7 +47,7 @@ namespace SQLite.Net.Tests
             public TestDb(ISQLitePlatform sqlitePlatform, String path)
                 : base(sqlitePlatform, path)
             {
-                Trace = true;
+                TraceListener = DebugTraceListener.Instance;
                 CreateTable<TestObj>();
             }
         }

--- a/tests/ConnectionTrackingTest.cs
+++ b/tests/ConnectionTrackingTest.cs
@@ -56,7 +56,7 @@ namespace SQLite.Net.Tests
             {
                 CreateTable<Product>();
                 CreateTable<OrderLine>();
-                Trace = true;
+                TraceListener = DebugTraceListener.Instance;
             }
         }
 

--- a/tests/ContainsTest.cs
+++ b/tests/ContainsTest.cs
@@ -57,7 +57,7 @@ namespace SQLite.Net.Tests
 
             db.InsertAll(cq);
 
-            db.Trace = true;
+            db.TraceListener = DebugTraceListener.Instance;
 
             var tensq = new[] {"0", "10", "20"};
             List<TestObj> tens = (from o in db.Table<TestObj>() where tensq.Contains(o.Name) select o).ToList();
@@ -82,7 +82,7 @@ namespace SQLite.Net.Tests
 
             db.InsertAll(cq);
 
-            db.Trace = true;
+            db.TraceListener = DebugTraceListener.Instance;
 
             var tensq = new[] {"0", "10", "20"};
             List<TestObj> tens = (from o in db.Table<TestObj>() where tensq.Contains(o.Name) select o).ToList();

--- a/tests/DropTableTest.cs
+++ b/tests/DropTableTest.cs
@@ -31,7 +31,7 @@ namespace SQLite.Net.Tests
         {
             public TestDb() : base(new SQLitePlatformTest(), TestPath.GetTempFileName())
             {
-                Trace = true;
+                TraceListener = DebugTraceListener.Instance;
             }
         }
 

--- a/tests/InsertTest.cs
+++ b/tests/InsertTest.cs
@@ -99,7 +99,7 @@ namespace SQLite.Net.Tests
                     Text = "I am"
                 };
             TestObj[] objs = q.ToArray();
-            _db.Trace = false;
+            _db.TraceListener = DebugTraceListener.Instance;
 
             var sw = new Stopwatch();
             sw.Start();
@@ -216,7 +216,7 @@ namespace SQLite.Net.Tests
         [Test]
         public void InsertOrReplace()
         {
-            _db.Trace = true;
+            _db.TraceListener = DebugTraceListener.Instance;
             _db.InsertAll(from i in Enumerable.Range(1, 20)
                 select new TestObj
                 {

--- a/tests/MigrationTest.cs
+++ b/tests/MigrationTest.cs
@@ -25,7 +25,7 @@ namespace SQLite.Net.Tests
         {
             using (var db = new TestDb(true)
             {
-                Trace = true
+                TraceListener = DebugTraceListener.Instance
             })
             {
                 db.CreateTable<LowerId>();

--- a/tests/TestDb.cs
+++ b/tests/TestDb.cs
@@ -72,7 +72,7 @@ namespace SQLite.Net.Tests
         public TestDb(bool storeDateTimeAsTicks = false)
             : base(new SQLitePlatformTest(), TestPath.GetTempFileName(), storeDateTimeAsTicks)
         {
-            Trace = true;
+            TraceListener = DebugTraceListener.Instance;
         }
     }
 


### PR DESCRIPTION
Hi,

This allows clients of the SQLite.NET PCL library to provide a handler for any trace messages, which can be very useful for application developers who want to route the SQLite trace messages to their own logs, for example.

Cheers,
Kent
