### PR TITLE
Fixes WP8 DB creation bug

### DIFF
--- a/src/SQLite.Net.Platform.WindowsPhone8/SQLiteApiWP8.cs
+++ b/src/SQLite.Net.Platform.WindowsPhone8/SQLiteApiWP8.cs
@@ -9,7 +9,7 @@ namespace SQLite.Net.Platform.WindowsPhone8
     {
         public Result Open(byte[] filename, out IDbHandle db, int flags, IntPtr zVfs)
         {
-            string dbFileName = Encoding.UTF8.GetString(filename, 0, filename.Length);
+            string dbFileName = Encoding.UTF8.GetString(filename, 0, filename.Length -1 );
             Database internalDbHandle = null;
             var ret = (Result)Sqlite3.sqlite3_open_v2(dbFileName, out internalDbHandle, flags, "");
             db = new DbHandle(internalDbHandle);


### PR DESCRIPTION
Fixes bug that prevents creation of DB on WP8

Solution found on : http://stackoverflow.com/questions/20873946/i-cannot-create-sqliteconnection-in-pcl-version-of-sqlite-net-on-wp8
