### PR TITLE
Expose whether the SQLiteConnectionWithLock is locked

### DIFF
--- a/src/SQLite.Net/SQLite.Net.csproj
+++ b/src/SQLite.Net/SQLite.Net.csproj
@@ -9,11 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SQLite.Net</RootNamespace>
     <AssemblyName>SQLite.Net</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile136</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
     <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/SQLite.Net/SQLiteConnectionWithLock.cs
+++ b/src/SQLite.Net/SQLiteConnectionWithLock.cs
@@ -45,6 +45,11 @@ namespace SQLite.Net
             return new LockWrapper(_lockPoint);
         }
 
+        public bool IsLocked()
+        {
+            return Monitor.IsEntered(_lockPoint);
+        }
+
         private class LockWrapper : IDisposable
         {
             private readonly object _lockPoint;


### PR DESCRIPTION
I want to enforce the `SQLiteConnectionWithLock` to be locked before calling any other methods on it, such as `Table<T>()`.

Given a wrapper class around `SQLiteConnectionWithLock`, like so:

```
public class Repository<T>
{
    protected readonly SQLiteConnectionWithLock connection;

    public BaseRepository(SQLiteConnectionWithLock connection)
    {
        this.connection = connection;
        connection.CreateTable<T>();
    }

    public IEnumerable<T> All()
    {
        AssertConenctionLocked();
        return connection.Table<T>();
    }

    public IDisposable Lock()
    {
        return connection.Lock();
    }

    private void AssertConenctionLocked()
    {
        if (!connection.IsLocked()) throw new NotLockedException();
    }
}
```

This allows me to enforce the call to `repository.Lock()` before `repository.All()`, so the following code will fail:

```
var connection = GetConnection();
var repository = new Repository<T>(connection);
repository.All();
```

but this won't:

```
var connection = GetConnection();
var repository = new Repository<T>(connection);

using (repository.Lock()) {
    repository.All();
}
```
