### PR TITLE
Fix target framework dir for Profile136

### DIFF
--- a/nuget/SQLite.Net.Async.nuspec
+++ b/nuget/SQLite.Net.Async.nuspec
@@ -23,6 +23,6 @@ Add support for custom Blob serializer (thanks @sami1971).</releaseNotes>
         </dependencies>
     </metadata>
     <files>
-        <file src="SQLite.Net.Async\SQLite.Net.Async.dll" target="lib\portable-net4+sl5+wp8+win8+monotouch+monoAndroid\SQLite.Net.Async.dll" />
+        <file src="SQLite.Net.Async\SQLite.Net.Async.dll" target="lib\portable-net4+sl5+netcore45+wp8+MonoAndroid1+MonoTouch1\SQLite.Net.Async.dll" />
     </files>
 </package>

--- a/nuget/SQLite.Net.nuspec
+++ b/nuget/SQLite.Net.nuspec
@@ -20,6 +20,6 @@ Add support for custom Blob serializer (thanks @sami1971).</releaseNotes>
         <tags>sqlite pcl sql database monotouch ios monodroid android win32 metro winrt</tags>
     </metadata>
     <files>
-        <file src="SQLite.Net\SQLite.Net.dll" target="lib\portable-net4+sl4+wp7+win8+monotouch+MonoAndroid\SQLite.Net.dll" />
+        <file src="SQLite.Net\SQLite.Net.dll" target="lib\portable-net4+sl5+netcore45+wp8+MonoAndroid1+MonoTouch1\SQLite.Net.dll" />
     </files>
 </package>


### PR DESCRIPTION
According to [Portable Class Library profiles](http://embed.plnkr.co/03ck2dCtnJogBKHJ9EjY/preview), the correct target framework directory for a PCL using `Profile136` is `portable-net4+sl5+netcore45+wp8+MonoAndroid1+MonoTouch1`.
