### PR TITLE
Expanded support for ThenBy* and Select projections

### DIFF
--- a/src/SQLite.Net.Async/AsyncTableQuery.cs
+++ b/src/SQLite.Net.Async/AsyncTableQuery.cs
@@ -88,6 +88,24 @@ namespace SQLite.Net.Async
             return new AsyncTableQuery<T>(_innerQuery.OrderByDescending(orderExpr), _taskScheduler ?? TaskScheduler.Default, _taskCreationOptions);
         }
 
+        public AsyncTableQuery<T> ThenBy<TValue>(Expression<Func<T, TValue>> orderExpr)
+        {
+            if (orderExpr == null)
+            {
+                throw new ArgumentNullException("orderExpr");
+            }
+            return new AsyncTableQuery<T>(_innerQuery.ThenBy(orderExpr), _taskScheduler ?? TaskScheduler.Default, _taskCreationOptions);
+        }
+
+        public AsyncTableQuery<T> ThenByDescending<TValue>(Expression<Func<T, TValue>> orderExpr)
+        {
+            if (orderExpr == null)
+            {
+                throw new ArgumentNullException("orderExpr");
+            }
+            return new AsyncTableQuery<T>(_innerQuery.ThenByDescending(orderExpr), _taskScheduler ?? TaskScheduler.Default, _taskCreationOptions);
+        }
+
         public Task<List<T>> ToListAsync()
         {
             return Task.Factory.StartNew(() =>

--- a/src/SQLite.Net/TableQuery.cs
+++ b/src/SQLite.Net/TableQuery.cs
@@ -153,6 +153,16 @@ namespace SQLite.Net
             return AddOrderBy(orderExpr, false);
         }
 
+        public TableQuery<T> ThenBy<TValue>(Expression<Func<T, TValue>> orderExpr)
+        {
+            return AddOrderBy<TValue>(orderExpr, true);
+        }
+
+        public TableQuery<T> ThenByDescending<TValue>(Expression<Func<T, TValue>> orderExpr)
+        {
+            return AddOrderBy<TValue>(orderExpr, false);
+        }
+
         private TableQuery<T> AddOrderBy<TValue>(Expression<Func<T, TValue>> orderExpr, bool asc)
         {
             if (orderExpr.NodeType == ExpressionType.Lambda)

--- a/tests/AsyncTests.cs
+++ b/tests/AsyncTests.cs
@@ -299,6 +299,59 @@ namespace SQLite.Net.Tests
         }
 
         [Test]
+        public async Task TestAsyncTableThenBy()
+        {
+            SQLiteAsyncConnection conn = GetConnection();
+            await conn.CreateTableAsync<Customer>();
+            await conn.ExecuteAsync("delete from customer");
+
+            // create...
+            for (int index = 0; index < 10; index++)
+            {
+                await conn.InsertAsync(CreateCustomer());
+            }
+            var preceedingFirstNameCustomer = CreateCustomer();
+            preceedingFirstNameCustomer.FirstName = "a" + preceedingFirstNameCustomer.FirstName;
+            await conn.InsertAsync(preceedingFirstNameCustomer);
+
+            // query...
+            AsyncTableQuery<Customer> query = conn.Table<Customer>().OrderBy(v => v.FirstName).ThenBy(v => v.Email);
+            var items = await query.ToListAsync();
+
+            // check...
+            var list = (await conn.Table<Customer>().ToListAsync()).OrderBy(v => v.FirstName).ThenBy(v => v.Email).ToList();
+            for (var i = 0; i < list.Count; i++)
+                Assert.AreEqual(list[i].Email, items[i].Email);
+        }
+
+        [Test]
+        public async Task TestAsyncTableThenByDescending()
+        {
+            SQLiteAsyncConnection conn = GetConnection();
+            await conn.CreateTableAsync<Customer>();
+            await conn.ExecuteAsync("delete from customer");
+
+            // create...
+            for (int index = 0; index < 10; index++)
+            {
+                await conn.InsertAsync(CreateCustomer());
+            }
+            var preceedingFirstNameCustomer = CreateCustomer();
+            preceedingFirstNameCustomer.FirstName = "a" + preceedingFirstNameCustomer.FirstName;
+            await conn.InsertAsync(preceedingFirstNameCustomer);
+
+            // query...
+            AsyncTableQuery<Customer> query = conn.Table<Customer>().OrderBy(v => v.FirstName).ThenByDescending(v => v.Email);
+            var items = await query.ToListAsync();
+
+
+            // check...
+            var list = (await conn.Table<Customer>().ToListAsync()).OrderBy(v => v.FirstName).ThenByDescending(v => v.Email).ToList();
+            for (var i = 0; i < list.Count; i++)
+                Assert.AreEqual(list[i].Email, items[i].Email);
+        }
+
+        [Test]
         public async Task TestAsyncTableQueryCountAsync()
         {
             SQLiteAsyncConnection conn = GetConnection();


### PR DESCRIPTION
Making TableQuery's Clone method generic enables Select projections. Also, ThenBy\* methods were add with tests.

Note: this is a new pull request. My attempts to squash were futile in GitHub for Windows. I reforked and made the same changes. Close the old PR.
