### PR TITLE
Insert or replace async

### DIFF
--- a/src/SQLite.Net.Async/SQLiteAsyncConnection.cs
+++ b/src/SQLite.Net.Async/SQLiteAsyncConnection.cs
@@ -169,6 +169,22 @@ namespace SQLite.Net.Async
             }, CancellationToken.None, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
+        public Task<int> InsertOrReplaceAsync(object item)
+        {
+            if (item == null)
+            {
+                throw new ArgumentNullException("item");
+            }
+            return Task.Factory.StartNew(() =>
+            {
+                SQLiteConnectionWithLock conn = GetConnection();
+                using (conn.Lock())
+                {
+                    return conn.InsertOrReplace(item);
+                }
+            }, CancellationToken.None, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
+        }
+
         public Task<int> DeleteAsync(object item)
         {
             if (item == null)
@@ -313,6 +329,22 @@ namespace SQLite.Net.Async
                 using (conn.Lock())
                 {
                     return conn.InsertAll(items);
+                }
+            }, CancellationToken.None, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
+        }
+
+        public Task<int> InsertOrReplaceAllAsync(IEnumerable items)
+        {
+            if (items == null)
+            {
+                throw new ArgumentNullException("items");
+            }
+            return Task.Factory.StartNew(() =>
+            {
+                SQLiteConnectionWithLock conn = GetConnection();
+                using (conn.Lock())
+                {
+                    return conn.InsertOrReplaceAll(items);
                 }
             }, CancellationToken.None, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }

--- a/src/SQLite.Net/SQLiteConnection.cs
+++ b/src/SQLite.Net/SQLiteConnection.cs
@@ -1113,6 +1113,32 @@ namespace SQLite.Net
         }
 
         /// <summary>
+        ///     Inserts all specified objects.
+        ///     For each insertion, if a UNIQUE 
+        ///     constraint violation occurs with
+        ///     some pre-existing object, this function
+        ///     deletes the old object.
+        /// </summary>
+        /// <param name="objects">
+        ///     An <see cref="IEnumerable" /> of the objects to insert or replace.
+        /// </param>
+        /// <returns>
+        ///     The total number of rows modified.
+        /// </returns>
+        public int InsertOrReplaceAll(IEnumerable objects)
+        {
+            int c = 0;
+            RunInTransaction(() =>
+            {
+                foreach (object r in objects)
+                {
+                    c += InsertOrReplace(r);
+                }
+            });
+            return c;
+        }
+
+        /// <summary>
         ///     Inserts the given object and retrieves its
         ///     auto incremented primary key if it has one.
         /// </summary>
@@ -1149,6 +1175,35 @@ namespace SQLite.Net
         public int InsertOrReplace(object obj, Type objType)
         {
             return Insert(obj, "OR REPLACE", objType);
+        }
+
+        /// <summary>
+        ///     Inserts all specified objects.
+        ///     For each insertion, if a UNIQUE 
+        ///     constraint violation occurs with
+        ///     some pre-existing object, this function
+        ///     deletes the old object.
+        /// </summary>
+        /// <param name="objects">
+        ///     An <see cref="IEnumerable" /> of the objects to insert or replace.
+        /// </param>
+        /// <param name="objType">
+        ///     The type of objects to insert or replace.
+        /// </param>
+        /// <returns>
+        ///     The total number of rows modified.
+        /// </returns>
+        public int InsertOrReplaceAll(IEnumerable objects, Type objType)
+        {
+            int c = 0;
+            RunInTransaction(() =>
+            {
+                foreach (object r in objects)
+                {
+                    c += InsertOrReplace(r, objType);
+                }
+            });
+            return c;
         }
 
         /// <summary>


### PR DESCRIPTION
Noticed that the async library was missing `InsertOrReplaceAsync()` method, which I've found useful in the synchronous version, so I added it along with a `InsertOrReplaceAll()` and corresponding `InsertOrReplaceAllAsync()` methods and tests.  @softlion has something similar in his large pull request, but that's been hanging around for a few months and I don't know if he has any plans to further pursue merging it.

Sorry for the ugly diff on `SQLIteConnection.cs` -- the intermingling of the `Insert()`, `InsertAll()`, and `InsertOrReplace()` methods really bugged me (makes them harder to find), so I segregated them.  The only new thing in that file is the `InsertOrReplaceAll()` method.
