### PR TITLE
Expose `GetConnection()` to subtypes

### DIFF
--- a/src/SQLite.Net.Async/SQLiteAsyncConnection.cs
+++ b/src/SQLite.Net.Async/SQLiteAsyncConnection.cs
@@ -47,7 +47,7 @@ namespace SQLite.Net.Async
             _taskScheduler = taskScheduler;
         }
 
-        private SQLiteConnectionWithLock GetConnection()
+        protected SQLiteConnectionWithLock GetConnection()
         {
             return _sqliteConnectionFunc();
         }


### PR DESCRIPTION
Given `GetConnection()` is the only way to get from the `SQLiteAsyncConnection` back to the `SQLiteConnectionWithLock`, it would be nice to mark it `protected` to enable any classes extending from `SQLiteAsyncConnection` to gain access to it in order to build on top of it.
