### PR TITLE
Implement Initialize, Shutdown & Config to allow Serialized Mode in PCL

### DIFF
--- a/src/SQLite.Net.Platform.Generic/SQLiteApiGeneric.cs
+++ b/src/SQLite.Net.Platform.Generic/SQLiteApiGeneric.cs
@@ -25,6 +25,19 @@ namespace SQLite.Net.Platform.Generic
             var internalDbHandle = (DbHandle) db;
             return SQLiteApiGenericInternal.sqlite3_close(internalDbHandle.DbPtr);
         }
+        public Result Initialize()
+        {
+            return SQLiteApiGenericInternal.sqlite3_initialize();
+        }
+        public Result Shutdown()
+        {
+            return SQLiteApiGenericInternal.sqlite3_shutdown();
+        }
+
+        public Result Config(ConfigOption option)
+        {
+            return SQLiteApiGenericInternal.sqlite3_config(option);
+        }
 
         public Result BusyTimeout(IDbHandle db, int milliseconds)
         {

--- a/src/SQLite.Net.Platform.Generic/SQLiteApiGenericInternal.cs
+++ b/src/SQLite.Net.Platform.Generic/SQLiteApiGenericInternal.cs
@@ -60,6 +60,12 @@ namespace SQLite.Net.Platform.Generic
         [DllImport("sqlite3", EntryPoint = "sqlite3_close", CallingConvention = CallingConvention.Cdecl)]
         public static extern Result sqlite3_close(IntPtr db);
 
+        [DllImport("sqlite3", EntryPoint = "sqlite3_initialize", CallingConvention = CallingConvention.Cdecl)]
+        public static extern Result sqlite3_initialize();
+
+        [DllImport("sqlite3", EntryPoint = "sqlite3_shutdown", CallingConvention = CallingConvention.Cdecl)]
+        public static extern Result sqlite3_shutdown();
+
         [DllImport("sqlite3", EntryPoint = "sqlite3_column_blob", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr sqlite3_column_blob(IntPtr stmt, int index);
 

--- a/src/SQLite.Net.Platform.Win32/SQLiteApiWin32.cs
+++ b/src/SQLite.Net.Platform.Win32/SQLiteApiWin32.cs
@@ -26,6 +26,21 @@ namespace SQLite.Net.Platform.Win32
             return SQLiteApiWin32Internal.sqlite3_close(internalDbHandle.DbPtr);
         }
 
+        public Result Initialize()
+        {
+            return SQLiteApiWin32Internal.sqlite3_initialize();
+        }
+        public Result Shutdown()
+        {
+            return SQLiteApiWin32Internal.sqlite3_shutdown();
+        }
+
+        public Result Config(ConfigOption option)
+        {
+            return SQLiteApiWin32Internal.sqlite3_config(option);
+        }
+
+
         public Result BusyTimeout(IDbHandle db, int milliseconds)
         {
             var internalDbHandle = (DbHandle) db;

--- a/src/SQLite.Net.Platform.Win32/SQliteApiWin32Internal.cs
+++ b/src/SQLite.Net.Platform.Win32/SQliteApiWin32Internal.cs
@@ -47,6 +47,12 @@ namespace SQLite.Net.Platform.Win32
         [DllImport("SQLite.Interop.dll", EntryPoint = "sqlite3_close", CallingConvention = CallingConvention.Cdecl)]
         public static extern Result sqlite3_close(IntPtr db);
 
+        [DllImport("SQLite.Interop.dll", EntryPoint = "sqlite3_initialize", CallingConvention = CallingConvention.Cdecl)]
+        public static extern Result sqlite3_initialize();
+
+        [DllImport("SQLite.Interop.dll", EntryPoint = "sqlite3_shutdown", CallingConvention = CallingConvention.Cdecl)]
+        public static extern Result sqlite3_shutdown();
+
         [DllImport("SQLite.Interop.dll", EntryPoint = "sqlite3_config", CallingConvention = CallingConvention.Cdecl)]
         public static extern Result sqlite3_config(ConfigOption option);
 

--- a/src/SQLite.Net.Platform.WinRT/SQLiteApiWinRT.cs
+++ b/src/SQLite.Net.Platform.WinRT/SQLiteApiWinRT.cs
@@ -69,6 +69,21 @@ namespace SQLite.Net.Platform.WinRT
             return (Result)SQLite3.Close(dbHandle.InternalDbHandle);
         }
 
+        public Result Initialize()
+        {
+            throw new NotSupportedException();
+        }
+        public Result Shutdown()
+        {
+            throw new NotSupportedException();
+        }
+
+        public Result Config(ConfigOption option)
+        {
+            return (Result)SQLite3.Config(option);
+        }
+
+
         public byte[] ColumnBlob(IDbStatement stmt, int index)
         {
             var dbStatement = (DbStatement)stmt;

--- a/src/SQLite.Net.Platform.WindowsPhone8/SQLiteApiWP8.cs
+++ b/src/SQLite.Net.Platform.WindowsPhone8/SQLiteApiWP8.cs
@@ -28,6 +28,20 @@ namespace SQLite.Net.Platform.WindowsPhone8
             return (Result)Sqlite3.sqlite3_close(dbHandle.InternalDbHandle);
         }
 
+        public Result Initialize()
+        {
+            throw new NotSupportedException();
+        }
+        public Result Shutdown()
+        {
+            throw new NotSupportedException();
+        }
+
+        public Result Config(ConfigOption option)
+        {
+            throw new NotSupportedException();
+        }
+
         public Result BusyTimeout(IDbHandle db, int milliseconds)
         {
             var dbHandle = (DbHandle)db;

--- a/src/SQLite.Net.Platform.XamarinAndroid/SQLiteApiAndroid.cs
+++ b/src/SQLite.Net.Platform.XamarinAndroid/SQLiteApiAndroid.cs
@@ -26,6 +26,20 @@ namespace SQLite.Net.Platform.XamarinAndroid
             return SQLiteApiAndroidInternal.sqlite3_close(internalDbHandle.DbPtr);
         }
 
+        public Result Initialize()
+        {
+            return SQLiteApiAndroidInternal.sqlite3_initialize();
+        }
+        public Result Shutdown()
+        {
+            return SQLiteApiAndroidInternal.sqlite3_shutdown();
+        }
+
+        public Result Config(ConfigOption option)
+        {
+            return SQLiteApiAndroidInternal.sqlite3_config(option);
+        }
+
         public Result BusyTimeout(IDbHandle db, int milliseconds)
         {
             var internalDbHandle = (DbHandle) db;
@@ -213,5 +227,7 @@ namespace SQLite.Net.Platform.XamarinAndroid
                 return other is DbStatement && StmtPtr == ((DbStatement) other).StmtPtr;
             }
         }
+
+
     }
 }

--- a/src/SQLite.Net.Platform.XamarinAndroid/SQLiteApiAndroidInternal.cs
+++ b/src/SQLite.Net.Platform.XamarinAndroid/SQLiteApiAndroidInternal.cs
@@ -62,6 +62,12 @@ namespace SQLite.Net.Platform.XamarinAndroid
         [DllImport(DllName, EntryPoint = "sqlite3_close", CallingConvention = CallingConvention.Cdecl)]
         public static extern Result sqlite3_close(IntPtr db);
 
+        [DllImport("sqlite3", EntryPoint = "sqlite3_initialize", CallingConvention = CallingConvention.Cdecl)]
+        public static extern Result sqlite3_initialize();
+
+        [DllImport("sqlite3", EntryPoint = "sqlite3_shutdown", CallingConvention = CallingConvention.Cdecl)]
+        public static extern Result sqlite3_shutdown();
+
         [DllImport(DllName, EntryPoint = "sqlite3_column_blob", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr sqlite3_column_blob(IntPtr stmt, int index);
 

--- a/src/SQLite.Net.Platform.XamarinIOS/SQLiteApiIOS.cs
+++ b/src/SQLite.Net.Platform.XamarinIOS/SQLiteApiIOS.cs
@@ -26,6 +26,20 @@ namespace SQLite.Net.Platform.XamarinIOS
             return SQLiteApiIOSInternal.sqlite3_close(internalDbHandle.DbPtr);
         }
 
+        public Result Initialize()
+        {
+            return SQLiteApiIOSInternal.sqlite3_initialize();
+        }
+        public Result Shutdown()
+        {
+            return SQLiteApiIOSInternal.sqlite3_shutdown();
+        }
+
+        public Result Config(ConfigOption option)
+        {
+            return SQLiteApiIOSInternal.sqlite3_config(option);
+        }
+
         public Result BusyTimeout(IDbHandle db, int milliseconds)
         {
             var internalDbHandle = (DbHandle) db;

--- a/src/SQLite.Net.Platform.XamarinIOS/SQLiteApiIOSInternal.cs
+++ b/src/SQLite.Net.Platform.XamarinIOS/SQLiteApiIOSInternal.cs
@@ -62,6 +62,12 @@ namespace SQLite.Net.Platform.XamarinIOS
         [DllImport(DllName, EntryPoint = "sqlite3_close", CallingConvention = CallingConvention.Cdecl)]
         public static extern Result sqlite3_close(IntPtr db);
 
+        [DllImport("sqlite3", EntryPoint = "sqlite3_initialize", CallingConvention = CallingConvention.Cdecl)]
+        public static extern Result sqlite3_initialize();
+
+        [DllImport("sqlite3", EntryPoint = "sqlite3_shutdown", CallingConvention = CallingConvention.Cdecl)]
+        public static extern Result sqlite3_shutdown();
+
         [DllImport(DllName, EntryPoint = "sqlite3_column_blob", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr sqlite3_column_blob(IntPtr stmt, int index);
 

--- a/src/SQLite.Net/Interop/ISQLiteApi.cs
+++ b/src/SQLite.Net/Interop/ISQLiteApi.cs
@@ -33,7 +33,9 @@ namespace SQLite.Net.Interop
 
         Result Close(IDbHandle db);
 
-        //        Result Config(ConfigOption option);
+        Result Initialize();
+        Result Shutdown();
+        Result Config(ConfigOption option);
 
         //        int SetDirectory(uint directoryType, string directoryPath);
 


### PR DESCRIPTION
The purpose of this change is to implement Initialize, Shutdown and Config.
see #35.

This allows better multi threading ability on some platforms.

It can be used like this...

```
var platform = new SQLite.Net.Platform.XamarinIOS.SQLitePlatformIOS();

platform.SQLiteApi.Shutdown();
platform.SQLiteApi.Config(SQLite.Net.Interop.ConfigOption.Serialized);
platform.SQLiteApi.Initialize();
```

NotSupported exception on platforms not supporting this.
