### PR TITLE
> Fixed the issue with non-ASCII characters in the db path

### DIFF
--- a/src/SQLite.Net.Platform.WinRT/SQLiteApiWinRT.cs
+++ b/src/SQLite.Net.Platform.WinRT/SQLiteApiWinRT.cs
@@ -173,9 +173,8 @@ namespace SQLite.Net.Platform.WinRT
 
         public Result Open(byte[] filename, out IDbHandle db, int flags, IntPtr zvfs)
         {
-            string dbFileName = Encoding.UTF8.GetString(filename, 0, filename.Length);
             Sqlite3DatabaseHandle internalDbHandle;
-            var ret = (Result)SQLite3.Open(dbFileName, out internalDbHandle, flags, zvfs);
+            var ret = (Result)SQLite3.Open(filename, out internalDbHandle, flags, zvfs);
             db = new DbHandle(internalDbHandle);
             return ret;
         }


### PR DESCRIPTION
Re-converting the byte buffer into a string caused a wrong overload of sqlite3_open to be called and opening of the DB failed. I believe this patch from the mainstream sqlite-net has not been propagated to the WinRT specific implementation...

https://github.com/praeclarum/sqlite-net/pull/71
