### PR TITLE
Handle the DateTimeKind of a DateTime column

### DIFF
--- a/src/SQLite.Net/SQLiteCommand.cs
+++ b/src/SQLite.Net/SQLiteCommand.cs
@@ -322,7 +322,7 @@ namespace SQLite.Net
                     }
                     else
                     {
-                        isqLite3Api.BindText16(stmt, index, ((DateTime) value).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ"), -1, NegativePointer);
+                        isqLite3Api.BindText16(stmt, index, ((DateTime) value).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"), -1, NegativePointer);
                     }
                 }
                 else if (value is ISerializable<DateTime>)
@@ -333,7 +333,7 @@ namespace SQLite.Net
                     }
                     else
                     {
-                        isqLite3Api.BindText16(stmt, index, ((ISerializable<DateTime>)value).Serialize().ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ"), -1, NegativePointer);
+                        isqLite3Api.BindText16(stmt, index, ((ISerializable<DateTime>)value).Serialize().ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"), -1, NegativePointer);
                     }
                 }
                 else if (value.GetType().IsEnum)

--- a/src/SQLite.Net/SQLiteCommand.cs
+++ b/src/SQLite.Net/SQLiteCommand.cs
@@ -318,22 +318,22 @@ namespace SQLite.Net
                 {
                     if (storeDateTimeAsTicks)
                     {
-                        isqLite3Api.BindInt64(stmt, index, ((DateTime) value).Ticks);
+                        isqLite3Api.BindInt64(stmt, index, ((DateTime) value).ToUniversalTime().Ticks);
                     }
                     else
                     {
-                        isqLite3Api.BindText16(stmt, index, ((DateTime) value).ToString("yyyy-MM-dd HH:mm:ss"), -1, NegativePointer);
+                        isqLite3Api.BindText16(stmt, index, ((DateTime) value).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ"), -1, NegativePointer);
                     }
                 }
                 else if (value is ISerializable<DateTime>)
                 {
                     if (storeDateTimeAsTicks)
                     {
-                        isqLite3Api.BindInt64(stmt, index, ((ISerializable<DateTime>)value).Serialize().Ticks);
+                        isqLite3Api.BindInt64(stmt, index, ((ISerializable<DateTime>)value).Serialize().ToUniversalTime().Ticks);
                     }
                     else
                     {
-                        isqLite3Api.BindText16(stmt, index, ((ISerializable<DateTime>)value).Serialize().ToString("yyyy-MM-dd HH:mm:ss"), -1, NegativePointer);
+                        isqLite3Api.BindText16(stmt, index, ((ISerializable<DateTime>)value).Serialize().ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ"), -1, NegativePointer);
                     }
                 }
                 else if (value.GetType().IsEnum)
@@ -432,7 +432,7 @@ namespace SQLite.Net
             {
                 if (_conn.StoreDateTimeAsTicks)
                 {
-                    return new DateTime(_sqlitePlatform.SQLiteApi.ColumnInt64(stmt, index));
+                    return new DateTime(_sqlitePlatform.SQLiteApi.ColumnInt64(stmt, index), DateTimeKind.Utc);
                 }
                 return DateTime.Parse(_sqlitePlatform.SQLiteApi.ColumnText16(stmt, index));
             }

--- a/tests/DateTimeTest.cs
+++ b/tests/DateTimeTest.cs
@@ -45,7 +45,7 @@ namespace SQLite.Net.Tests
             //
             o = new TestObj
             {
-                ModifiedTime = new DateTime(2012, 1, 14, 3, 2, 1, DateTimeKind.Utc),
+                ModifiedTime = DateTime.UtcNow,
             };
             await db.InsertAsync(o);
             o2 = await db.GetAsync<TestObj>(o.Id);
@@ -66,7 +66,7 @@ namespace SQLite.Net.Tests
             //
             o = new TestObj
             {
-                ModifiedTime = new DateTime(2012, 1, 14, 3, 2, 1, DateTimeKind.Utc),
+                ModifiedTime = DateTime.UtcNow,
             };
             db.Insert(o);
             o2 = db.Get<TestObj>(o.Id);


### PR DESCRIPTION
All `DateTime` properties coming back from SQLite.Net-PCL had a `DateTimeKind` of `Unspecified` which isn't ideal.

The simplest solution was to convert all `DateTime` objects to UTC using the `ToUniversalTime()` method, before serialising them into SQLite, with an explicit 'Z' suffix when `StoreDateTimeAsTicks` is disabled and we use have to call `ToString()`.

This means that we must pass an explicit `DateTimeKind` of `Utc` to the `new DateTime` call on `SQLiteCommand#L435` for when `StoreDateTimeAsTicks` is enabled. The `DateTime.Parse` on `SQLiteCommand#L437` will start returning a `DateTime` with the correct `DateTimeKind` since we added the 'Z' suffix to the value we store on `SQLiteCommand#L325`.

Any questions?