### PR TITLE
Implement CancellationToken support for async method calls (Issue#55)

### DIFF
--- a/src/SQLite.Net.Async/AsyncTableQuery.cs
+++ b/src/SQLite.Net.Async/AsyncTableQuery.cs
@@ -158,37 +158,37 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-		public Task<T> FirstAsync()
-		{
-			return FirstAsync (CancellationToken.None);
-		}
+        public Task<T> FirstAsync()
+        {
+            return FirstAsync (CancellationToken.None);
+        }
 
-		public Task<T> FirstAsync(CancellationToken cancellationToken)
+        public Task<T> FirstAsync(CancellationToken cancellationToken)
         {
             return Task.Factory.StartNew(() =>
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 using (((SQLiteConnectionWithLock)_innerQuery.Connection).Lock())
                 {
-					cancellationToken.ThrowIfCancellationRequested();
+                    cancellationToken.ThrowIfCancellationRequested();
                     return _innerQuery.First();
                 }
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-		public Task<T> FirstOrDefaultAsync()
-		{
-			return FirstOrDefaultAsync(CancellationToken.None);
-		}
+        public Task<T> FirstOrDefaultAsync()
+        {
+            return FirstOrDefaultAsync(CancellationToken.None);
+        }
 
-		public Task<T> FirstOrDefaultAsync(CancellationToken cancellationToken)
+        public Task<T> FirstOrDefaultAsync(CancellationToken cancellationToken)
         {
             return Task.Factory.StartNew(() =>
             {
-				cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
                 using (((SQLiteConnectionWithLock)_innerQuery.Connection).Lock())
                 {
-					cancellationToken.ThrowIfCancellationRequested();
+                    cancellationToken.ThrowIfCancellationRequested();
                     return _innerQuery.FirstOrDefault();
                 }
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);

--- a/src/SQLite.Net.Async/SQLiteAsyncConnection.cs
+++ b/src/SQLite.Net.Async/SQLiteAsyncConnection.cs
@@ -229,11 +229,11 @@ namespace SQLite.Net.Async
             }, CancellationToken.None, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-		public Task<T> GetAsync<T>(object pk)
-			where T : new()
-		{
-			return GetAsync<T>(CancellationToken.None, pk);
-		}
+        public Task<T> GetAsync<T>(object pk)
+            where T : new()
+        {
+            return GetAsync<T>(CancellationToken.None, pk);
+        }
 
         public Task<T> GetAsync<T>(CancellationToken cancellationToken, object pk)
             where T : new()
@@ -244,71 +244,71 @@ namespace SQLite.Net.Async
             }
             return Task.Factory.StartNew(() =>
             {
-				cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
                 SQLiteConnectionWithLock conn = GetConnection();
                 using (conn.Lock())
                 {
-					cancellationToken.ThrowIfCancellationRequested();
+                    cancellationToken.ThrowIfCancellationRequested();
                     return conn.Get<T>(pk);
                 }
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-		public Task<T> FindAsync<T>(object pk)
-			where T : new()
-		{
-			return FindAsync<T>(CancellationToken.None, pk);
-		}
-
-		public Task<T> FindAsync<T>(CancellationToken cancellationToken, object pk)
+        public Task<T> FindAsync<T>(object pk)
             where T : new()
         {
-		    if (pk == null)
+            return FindAsync<T>(CancellationToken.None, pk);
+        }
+
+        public Task<T> FindAsync<T>(CancellationToken cancellationToken, object pk)
+            where T : new()
+        {
+            if (pk == null)
             {
                 throw new ArgumentNullException("pk");
             }
             return Task.Factory.StartNew(() =>
             {
-				cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
                 SQLiteConnectionWithLock conn = GetConnection();
                 using (conn.Lock())
                 {
-					cancellationToken.ThrowIfCancellationRequested();
+                    cancellationToken.ThrowIfCancellationRequested();
                     return conn.Find<T>(pk);
                 }
             }, CancellationToken.None, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-		public Task<T> GetAsync<T>(Expression<Func<T, bool>> predicate)
-			where T : new()
-		{
-			return GetAsync<T>(CancellationToken.None, predicate);
-		}
+        public Task<T> GetAsync<T>(Expression<Func<T, bool>> predicate)
+            where T : new()
+        {
+            return GetAsync<T>(CancellationToken.None, predicate);
+        }
 
         public Task<T> GetAsync<T>(CancellationToken cancellationToken, Expression<Func<T, bool>> predicate)
             where T : new()
         {
-		    if (predicate == null)
+            if (predicate == null)
             {
                 throw new ArgumentNullException("predicate");
             }
             return Task.Factory.StartNew(() =>
             {
-				cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
                 SQLiteConnectionWithLock conn = GetConnection();
                 using (conn.Lock())
                 {
-					cancellationToken.ThrowIfCancellationRequested();
+                    cancellationToken.ThrowIfCancellationRequested();
                     return conn.Get(predicate);
                 }
             }, CancellationToken.None, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-		public Task<T> FindAsync<T>(Expression<Func<T, bool>> predicate)
-			where T : new()
-		{
-			return FindAsync<T>(CancellationToken.None, predicate);
-		}
+        public Task<T> FindAsync<T>(Expression<Func<T, bool>> predicate)
+            where T : new()
+        {
+            return FindAsync<T>(CancellationToken.None, predicate);
+        }
 
         public Task<T> FindAsync<T>(CancellationToken cancellationToken, Expression<Func<T, bool>> predicate)
             where T : new()
@@ -319,11 +319,11 @@ namespace SQLite.Net.Async
             }
             return Task.Factory.StartNew(() =>
             {
-				cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
                 SQLiteConnectionWithLock conn = GetConnection();
                 using (conn.Lock())
                 {
-					cancellationToken.ThrowIfCancellationRequested();
+                    cancellationToken.ThrowIfCancellationRequested();
                     return conn.Find(predicate);
                 }
             }, CancellationToken.None, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
@@ -410,24 +410,24 @@ namespace SQLite.Net.Async
             }, CancellationToken.None, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-		public Task RunInTransactionAsync(Action<SQLiteConnection> action)
-		{
-			return RunInTransactionAsync(CancellationToken.None, action);
-		}
+        public Task RunInTransactionAsync(Action<SQLiteConnection> action)
+        {
+            return RunInTransactionAsync(CancellationToken.None, action);
+        }
 
         public Task RunInTransactionAsync(CancellationToken cancellationToken, Action<SQLiteConnection> action)
         {
-			if (action == null)
-			{
-				throw new ArgumentNullException("action");
-			}
+            if (action == null)
+            {
+                throw new ArgumentNullException("action");
+            }
             return Task.Factory.StartNew(() =>
             {
-				cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
                 SQLiteConnectionWithLock conn = GetConnection();
                 using (conn.Lock())
                 {
-					cancellationToken.ThrowIfCancellationRequested();
+                    cancellationToken.ThrowIfCancellationRequested();
                     conn.BeginTransaction();
                     try
                     {
@@ -454,10 +454,10 @@ namespace SQLite.Net.Async
             return new AsyncTableQuery<T>(conn.Table<T>(), _taskScheduler, _taskCreationOptions);
         }
 
-		public Task<T> ExecuteScalarAsync<T>(string sql, params object[] args)
-		{
-			return ExecuteScalarAsync<T>(CancellationToken.None, sql, args);
-		}
+        public Task<T> ExecuteScalarAsync<T>(string sql, params object[] args)
+        {
+            return ExecuteScalarAsync<T>(CancellationToken.None, sql, args);
+        }
 
         public Task<T> ExecuteScalarAsync<T>(CancellationToken cancellationToken, string sql, params object[] args)
         {
@@ -475,20 +475,20 @@ namespace SQLite.Net.Async
                 SQLiteConnectionWithLock conn = GetConnection();
                 using (conn.Lock())
                 {
-					cancellationToken.ThrowIfCancellationRequested();
+                    cancellationToken.ThrowIfCancellationRequested();
                     SQLiteCommand command = conn.CreateCommand(sql, args);
                     return command.ExecuteScalar<T>();
                 }
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-		public Task<List<T>> QueryAsync<T>(string sql, params object[] args)
-			where T : new()
-		{
-			return QueryAsync<T> (CancellationToken.None, sql, args);
-		}
+        public Task<List<T>> QueryAsync<T>(string sql, params object[] args)
+            where T : new()
+        {
+            return QueryAsync<T> (CancellationToken.None, sql, args);
+        }
 
-		public Task<List<T>> QueryAsync<T>(CancellationToken cancellationToken, string sql, params object[] args)
+        public Task<List<T>> QueryAsync<T>(CancellationToken cancellationToken, string sql, params object[] args)
             where T : new()
         {
             if (sql == null)
@@ -501,11 +501,11 @@ namespace SQLite.Net.Async
             }
             return Task.Factory.StartNew(() =>
             {
-				cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
                 SQLiteConnectionWithLock conn = GetConnection();
                 using (conn.Lock())
                 {
-					cancellationToken.ThrowIfCancellationRequested();
+                    cancellationToken.ThrowIfCancellationRequested();
                     return conn.Query<T>(sql, args);
                 }
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);


### PR DESCRIPTION
Issue#55 requested support for CancellationTokens. This is important because otherwise a database request once queued up as a Task will always need to run to completion even if, by the time it gets to run, and by the time it acquires the global lock, it is no longer needed. For example, the user may have scrolled some listview further to display new cells or has moved to a different page in the application.

With this PR, the caller can use a CancellationTokenSource to cancel a pending operation and, if the task hasn't started executing yet, or the lock hasn't been acquired yet, the database call will not happen, saving valuable resources.

A further refinement would be to use an async locking mechanism that also supported cancellations (but that's a much bigger change than this fairly simple addition of new method signatures and a couple of checks in the cancellation token).
