### PR TITLE
[Fix] Nullable types in ExecuteScalar

### DIFF
--- a/src/SQLite.Net/SQLiteCommand.cs
+++ b/src/SQLite.Net/SQLiteCommand.cs
@@ -158,7 +158,8 @@ namespace SQLite.Net
                 if (r == Result.Row)
                 {
                     ColType colType = _sqlitePlatform.SQLiteApi.ColumnType(stmt, 0);
-                    val = (T)ReadCol(stmt, 0, colType, typeof(T));
+                    var clrType = Nullable.GetUnderlyingType(typeof (T)) ?? typeof (T);
+                    val = (T)ReadCol(stmt, 0, colType, clrType);
                 }
                 else if (r == Result.Done)
                 {

--- a/tests/NullableTest.cs
+++ b/tests/NullableTest.cs
@@ -83,6 +83,45 @@ namespace SQLite.Net.Tests
         }
 
         [Test]
+        public void NullableScalarInt()
+        {
+            var db = new SQLiteConnection(new SQLitePlatformTest(), TestPath.GetTempFileName());
+            db.CreateTable<NullableIntClass>();
+
+            var withNull = new NullableIntClass
+            {
+                NullableInt = null
+            };
+            var with0 = new NullableIntClass
+            {
+                NullableInt = 0
+            };
+            var with1 = new NullableIntClass
+            {
+                NullableInt = 1
+            };
+            var withMinus1 = new NullableIntClass
+            {
+                NullableInt = -1
+            };
+
+            db.Insert(withNull);
+            db.Insert(with0);
+            db.Insert(with1);
+            db.Insert(withMinus1);
+
+            var actualShouldBeNull   = db.ExecuteScalar<int?>("select NullableInt from NullableIntClass order by ID limit 1");
+            var actualShouldBe0      = db.ExecuteScalar<int?>("select NullableInt from NullableIntClass order by ID limit 1 offset 1");
+            var actualShouldBe1      = db.ExecuteScalar<int?>("select NullableInt from NullableIntClass order by ID limit 1 offset 2");
+            var actualShouldBeMinus1 = db.ExecuteScalar<int?>("select NullableInt from NullableIntClass order by ID limit 1 offset 3");
+
+            Assert.AreEqual(null, actualShouldBeNull);
+            Assert.AreEqual(0, actualShouldBe0);
+            Assert.AreEqual(1, actualShouldBe1);
+            Assert.AreEqual(-1, actualShouldBeMinus1);
+        }
+
+        [Test]
         [Description("Create a table with a nullable int column then insert and select against it")]
         public void NullableFloat()
         {


### PR DESCRIPTION
ExecuteScalar not support Nullable<> types. For example,

`db.ExecuteScalar<int?>()` fails with error: "System.NotSupportedException : Don't know how to read System.Nullable`1[System.Int32]"

This PR fixes the problem and adds the test.
