### PR TITLE
Fixed some bugs in the Table query code for to multiple calls to skip/take

### DIFF
--- a/src/SQLite.Net/TableQuery.cs
+++ b/src/SQLite.Net/TableQuery.cs
@@ -127,7 +127,7 @@ namespace SQLite.Net
         public TableQuery<T> Skip(int n)
         {
             TableQuery<T> q = Clone<T>();
-            q._offset = n;
+            q._offset = n + (q._offset ?? 0);
             return q;
         }
 

--- a/src/SQLite.Net/TableQuery.cs
+++ b/src/SQLite.Net/TableQuery.cs
@@ -120,13 +120,17 @@ namespace SQLite.Net
         public TableQuery<T> Take(int n)
         {
             TableQuery<T> q = Clone<T>();
-            q._limit = n;
+
+            // If there is already a limit then the limit will be the minimum
+            // of the current limit and n.
+            q._limit = Math.Min(q._limit ?? int.MaxValue, n);
             return q;
         }
 
         public TableQuery<T> Skip(int n)
         {
             TableQuery<T> q = Clone<T>();
+
             q._offset = n + (q._offset ?? 0);
             return q;
         }

--- a/tests/SkipTest.cs
+++ b/tests/SkipTest.cs
@@ -76,5 +76,32 @@ namespace SQLite.Net.Tests
             Assert.AreEqual(n - 5, s5.Count);
             Assert.AreEqual(6, s5[0].Order);
         }
+
+
+        [Test]
+        public void MultipleSkipsWillSkipTheSumOfTheSkips()
+        {
+            int n = 100;
+
+            IEnumerable<TestObj> cq = from i in Enumerable.Range(1, n)
+                                      select new TestObj
+                                      {
+                                          Order = i
+                                      };
+            TestObj[] objs = cq.ToArray();
+            var db = new TestDb(TestPath.GetTempFileName());
+
+            int numIn = db.InsertAll(objs);
+            Assert.AreEqual(numIn, n, "Num inserted must = num objects");
+
+            TableQuery<TestObj> q = from o in db.Table<TestObj>()
+                                    orderby o.Order
+                                    select o;
+
+            TableQuery<TestObj> qs1 = q.Skip(1).Skip(5);
+            List<TestObj> s1 = qs1.ToList();
+            Assert.AreEqual(n - 6, s1.Count,"Should have skipped 5 + 1 = 6 objects.");
+            Assert.AreEqual(7, s1[0].Order);
+        }
     }
 }

--- a/tests/SkipTest.cs
+++ b/tests/SkipTest.cs
@@ -103,5 +103,31 @@ namespace SQLite.Net.Tests
             Assert.AreEqual(n - 6, s1.Count,"Should have skipped 5 + 1 = 6 objects.");
             Assert.AreEqual(7, s1[0].Order);
         }
+
+        [Test]
+        public void MultipleTakesWillTakeTheMinOfTheTakes()
+        {
+            int n = 100;
+
+            IEnumerable<TestObj> cq = from i in Enumerable.Range(1, n)
+                                      select new TestObj
+                                      {
+                                          Order = i
+                                      };
+            TestObj[] objs = cq.ToArray();
+            var db = new TestDb(TestPath.GetTempFileName());
+
+            int numIn = db.InsertAll(objs);
+            Assert.AreEqual(numIn, n, "Num inserted must = num objects");
+
+            TableQuery<TestObj> q = from o in db.Table<TestObj>()
+                                    orderby o.Order
+                                    select o;
+
+            TableQuery<TestObj> qs1 = q.Take(1).Take(5);
+            List<TestObj> s1 = qs1.ToList();
+            Assert.AreEqual(1, s1.Count, "Should have taken exactly one object.");
+            Assert.AreEqual(1, s1[0].Order);
+        }
     }
 }


### PR DESCRIPTION
When skip or take was called multiple times, the result was a last one in wins rather than the correct coalescing of the operations.