### PR TITLE
Fix typo in d916c5d and add test

### DIFF
--- a/src/SQLite.Net/SQLiteCommand.cs
+++ b/src/SQLite.Net/SQLiteCommand.cs
@@ -159,7 +159,6 @@ namespace SQLite.Net
                 {
                     ColType colType = _sqlitePlatform.SQLiteApi.ColumnType(stmt, 0);
                     var clrType = Nullable.GetUnderlyingType(typeof (T)) ?? typeof (T);
-                    val = (T)ReadCol(stmt, 0, colType, clrType);
                     if (colType != ColType.Null)
                     {
                         val = (T) ReadCol(stmt, 0, colType, clrType);

--- a/tests/NullableTest.cs
+++ b/tests/NullableTest.cs
@@ -122,6 +122,17 @@ namespace SQLite.Net.Tests
         }
 
         [Test]
+        public void NullableSumTest()
+        {
+            SQLiteConnection db = new TestDb();
+            db.CreateTable<NullableIntClass>();
+
+            var r = db.ExecuteScalar<int>("SELECT SUM(NullableInt) FROM NullableIntClass WHERE 1 = 0");
+
+            Assert.AreEqual(0, r);
+        }
+
+        [Test]
         [Description("Create a table with a nullable int column then insert and select against it")]
         public void NullableFloat()
         {


### PR DESCRIPTION
Hi,

d916c5d46be00d87ffddccd29c4aa94b1e298ce5 does not resolve #171 because of a typo.

This PR adds test for #171 and fixes typo.