### PR TITLE
Found a bug with the combination of skip and where

### DIFF
--- a/src/SQLite.Net/Attributes/DefaultAttribute.cs
+++ b/src/SQLite.Net/Attributes/DefaultAttribute.cs
@@ -15,8 +15,8 @@ namespace SQLite.Net.Attributes
         /// <param name="value">The value to set as default if usePropertyValue is false</param>
         public DefaultAttribute(bool usePropertyValue = true, object value = null)
         {
+            UseProperty = usePropertyValue;
             Value = value;
         }
-
     }
 }

--- a/src/SQLite.Net/Orm.cs
+++ b/src/SQLite.Net/Orm.cs
@@ -149,9 +149,9 @@ namespace SQLite.Net
 
         public static string Collation(MemberInfo p)
         {
-            foreach (var attribute in p.CustomAttributes.Where(attribute => attribute.AttributeType == typeof(CollationAttribute)))
+            foreach (var attribute in p.GetCustomAttributes<CollationAttribute>())
             {
-                return (string)attribute.ConstructorArguments[0].Value;
+                return attribute.Value;
             }
             return string.Empty;
         }

--- a/src/SQLite.Net/Orm.cs
+++ b/src/SQLite.Net/Orm.cs
@@ -177,14 +177,12 @@ namespace SQLite.Net
 
         public static object GetDefaultValue(PropertyInfo p)
         {
-            foreach (var attribute in p.CustomAttributes.Where(a => a.AttributeType == typeof (DefaultAttribute)))
+            foreach (var attribute in p.GetCustomAttributes<DefaultAttribute>())
             {
                 try
                 {
-                    var useProp = (bool) attribute.ConstructorArguments[0].Value;
-
-                    if (!useProp)
-                        return Convert.ChangeType(attribute.ConstructorArguments[0].Value, p.PropertyType);
+                    if (!attribute.UseProperty)
+                        return Convert.ChangeType(attribute.Value, p.PropertyType);
 
                     var obj = Activator.CreateInstance(p.DeclaringType);
                     return p.GetValue(obj);
@@ -192,7 +190,7 @@ namespace SQLite.Net
                 }
                 catch (Exception exception)
                 {
-                    throw new Exception("Unable to convert " + attribute.ConstructorArguments[0].Value + " to type " + p.PropertyType, exception);
+                    throw new Exception("Unable to convert " + attribute.Value + " to type " + p.PropertyType, exception);
                 }
             }
             return null;

--- a/src/SQLite.Net/TableQuery.cs
+++ b/src/SQLite.Net/TableQuery.cs
@@ -212,6 +212,11 @@ namespace SQLite.Net
 
         private void AddWhere(Expression pred)
         {
+            if (_limit != null || _offset != null)
+            {
+                throw new NotSupportedException("Cannot call where after a skip or a take");
+            }
+
             if (_where == null)
             {
                 _where = pred;

--- a/src/SQLite.Net/TableQuery.cs
+++ b/src/SQLite.Net/TableQuery.cs
@@ -120,13 +120,17 @@ namespace SQLite.Net
         public TableQuery<T> Take(int n)
         {
             TableQuery<T> q = Clone<T>();
-            q._limit = n;
+
+            // If there is already a limit then the limit will be the minimum
+            // of the current limit and n.
+            q._limit = Math.Min(q._limit ?? int.MaxValue, n);
             return q;
         }
 
         public TableQuery<T> Skip(int n)
         {
             TableQuery<T> q = Clone<T>();
+
             q._offset = n + (q._offset ?? 0);
             return q;
         }

--- a/tests/CollateTest.cs
+++ b/tests/CollateTest.cs
@@ -89,5 +89,98 @@ namespace SQLite.Net.Tests
             Assert.AreEqual(0, (from o in db.Table<TestObj>() where o.CollateNoCase == "Alpha" select o).Count());
             Assert.AreEqual(0, (from o in db.Table<TestObj>() where o.CollateNoCase == "ALPHA" select o).Count());
         }
+
+        /// <summary>
+        /// A possible better way of specifying the type of the collation
+        /// </summary>
+        private enum CollationType
+        {
+            BINARY,
+            RTRIM,
+            NOCASE
+        }
+
+        /// <summary>
+        /// A subtype of the collation attribute that allows the use of <see cref="CollationType"/>
+        /// </summary>
+        private class EasierCollationAttribute : CollationAttribute
+        {
+            public EasierCollationAttribute(CollationType type) : base(type.ToString())
+            {
+                
+            }
+        }
+
+        public class TestObjWithSubtypedAttributes
+        {
+            [AutoIncrement, PrimaryKey]
+            public int Id { get; set; }
+
+            public string CollateDefault { get; set; }
+
+            [EasierCollation(CollationType.BINARY)]
+            public string CollateBinary { get; set; }
+
+            [EasierCollation(CollationType.RTRIM)]
+            public string CollateRTrim { get; set; }
+
+            [EasierCollation(CollationType.NOCASE)]
+            public string CollateNoCase { get; set; }
+
+            public override string ToString()
+            {
+                return string.Format("[TestObj: Id={0}]", Id);
+            }
+        }
+
+        public class TestDbSubtype : SQLiteConnection
+        {
+            public TestDbSubtype(ISQLitePlatform sqlitePlatform, String path)
+                : base(sqlitePlatform, path)
+            {
+                TraceListener = DebugTraceListener.Instance;
+                CreateTable<TestObjWithSubtypedAttributes>();
+            }
+        }
+
+        /// <summary>
+        /// The same test as before but with a subtyped collation attribute.
+        /// </summary>
+        [Test]
+        public void CollateAttributeSubtype()
+        {
+            var obj = new TestObjWithSubtypedAttributes
+            {
+                CollateDefault = "Alpha ",
+                CollateBinary = "Alpha ",
+                CollateRTrim = "Alpha ",
+                CollateNoCase = "Alpha ",
+            };
+
+            var db = new TestDbSubtype(new SQLitePlatformTest(), TestPath.GetTempFileName());
+
+            db.Insert(obj);
+
+            var testTable = db.Table<TestObjWithSubtypedAttributes>();
+            Assert.AreEqual(1, (from o in testTable where o.CollateDefault == "Alpha " select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateDefault == "ALPHA " select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateDefault == "Alpha" select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateDefault == "ALPHA" select o).Count());
+
+            Assert.AreEqual(1, (from o in testTable where o.CollateBinary == "Alpha " select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateBinary == "ALPHA " select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateBinary == "Alpha" select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateBinary == "ALPHA" select o).Count());
+
+            Assert.AreEqual(1, (from o in testTable where o.CollateRTrim == "Alpha " select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateRTrim == "ALPHA " select o).Count());
+            Assert.AreEqual(1, (from o in testTable where o.CollateRTrim == "Alpha" select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateRTrim == "ALPHA" select o).Count());
+
+            Assert.AreEqual(1, (from o in testTable where o.CollateNoCase == "Alpha " select o).Count());
+            Assert.AreEqual(1, (from o in testTable where o.CollateNoCase == "ALPHA " select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateNoCase == "Alpha" select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateNoCase == "ALPHA" select o).Count());
+        }
     }
 }

--- a/tests/DefaulAttributeTest.cs
+++ b/tests/DefaulAttributeTest.cs
@@ -28,7 +28,7 @@ namespace SQLite.Net.Tests
         private class WithDefaultValue
         {
 
-            public static int IntVal = 666;
+            public const int IntVal = 666;
             public static decimal DecimalVal = 666.666m;
             public static string StringVal = "Working String";
             public static DateTime DateTimegVal = new DateTime(2014, 2, 13);
@@ -57,6 +57,21 @@ namespace SQLite.Net.Tests
             [Default]
             public string TestString { get; set; }
 
+
+            [Default(value: IntVal, usePropertyValue: false)]
+            public int DefaultValueInAttributeTestInt { get; set; }
+
+            public class Default666Attribute : DefaultAttribute
+            {
+                public Default666Attribute() :base(usePropertyValue:false, value:IntVal)
+                {
+                    
+                }
+            }
+
+            [Default666]
+            public int TestIntWithSubtypeOfDefault { get; set; }
+
         }
 
         [Test]
@@ -73,6 +88,7 @@ namespace SQLite.Net.Tests
                     if (col.PropertyName == "TestInt" && !col.DefaultValue.Equals(WithDefaultValue.IntVal))
                         failed += " , TestInt does not equal " + WithDefaultValue.IntVal;
 
+
                     if (col.PropertyName == "TestDecimal" && !col.DefaultValue.Equals(WithDefaultValue.DecimalVal))
                         failed += "TestDecimal does not equal " + WithDefaultValue.DecimalVal;
 
@@ -81,8 +97,15 @@ namespace SQLite.Net.Tests
 
                     if (col.PropertyName == "TestString" && !col.DefaultValue.Equals(WithDefaultValue.StringVal))
                         failed += "TestString does not equal " + WithDefaultValue.StringVal;
+
+                    if (col.PropertyName == "DefaultValueInAttributeTestInt" && !col.DefaultValue.Equals(WithDefaultValue.IntVal))
+                        failed += " , DefaultValueInAttributeTestInt does not equal " + WithDefaultValue.IntVal;
+
+                    if (col.PropertyName == "TestIntWithSubtypeOfDefault" && !col.DefaultValue.Equals(WithDefaultValue.IntVal))
+                        failed += " , TestIntWithSubtypeOfDefault does not equal " + WithDefaultValue.IntVal;
+
                 }
-                
+
                 Assert.True(string.IsNullOrWhiteSpace(failed), failed);
 
             }

--- a/tests/SkipTest.cs
+++ b/tests/SkipTest.cs
@@ -103,5 +103,31 @@ namespace SQLite.Net.Tests
             Assert.AreEqual(n - 6, s1.Count,"Should have skipped 5 + 1 = 6 objects.");
             Assert.AreEqual(7, s1[0].Order);
         }
+
+        [Test]
+        public void MultipleTakesWillTakeTheMinOfTheTakes()
+        {
+            int n = 100;
+
+            IEnumerable<TestObj> cq = from i in Enumerable.Range(1, n)
+                                      select new TestObj
+                                      {
+                                          Order = i
+                                      };
+            TestObj[] objs = cq.ToArray();
+            var db = new TestDb(TestPath.GetTempFileName());
+
+            int numIn = db.InsertAll(objs);
+            Assert.AreEqual(numIn, n, "Num inserted must = num objects");
+
+            TableQuery<TestObj> q = from o in db.Table<TestObj>()
+                                    orderby o.Order
+                                    select o;
+
+            TableQuery<TestObj> qs1 = q.Take(1).Take(5);
+            List<TestObj> s1 = qs1.ToList();
+            Assert.AreEqual(1, s1.Count, "Should have taken exactly one object.");
+            Assert.AreEqual(1, s1[0].Order);
+        }
     }
 }


### PR DESCRIPTION
Created a test which showcases the bug, and changed the TableQuery code
to make it throw a NotSupportedException instead of returning a
potentially erroneous result set.

Calling Skip then Where on Table query was creating the same result as where then skip.