### PR TITLE
Found a bug with the combination of skip and where

### DIFF
--- a/src/SQLite.Net/TableQuery.cs
+++ b/src/SQLite.Net/TableQuery.cs
@@ -212,6 +212,11 @@ namespace SQLite.Net
 
         private void AddWhere(Expression pred)
         {
+            if (_limit != null || _offset != null)
+            {
+                throw new NotSupportedException("Cannot call where after a skip or a take");
+            }
+
             if (_where == null)
             {
                 _where = pred;


### PR DESCRIPTION
Created a test which showcases the bug, and changed the TableQuery code
to make it throw a NotSupportedException instead of returning a
potentially erroneous result set.

Calling Skip then Where on Table query was creating the same result as where then skip.