### PR TITLE
ReSharper attributes

### DIFF
--- a/src/SQLite.Net.Async/AsyncTableQuery.cs
+++ b/src/SQLite.Net.Async/AsyncTableQuery.cs
@@ -24,15 +24,16 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 
 namespace SQLite.Net.Async
 {
     public class AsyncTableQuery<T>
         where T : class
     {
-        private readonly TableQuery<T> _innerQuery;
-        private readonly TaskCreationOptions _taskCreationOptions = TaskCreationOptions.None;
-        private readonly TaskScheduler _taskScheduler;
+        [NotNull] private readonly TableQuery<T> _innerQuery;
+        private readonly TaskCreationOptions _taskCreationOptions;
+        [CanBeNull] private readonly TaskScheduler _taskScheduler;
 
         /// <summary>
         /// </summary>
@@ -42,7 +43,9 @@ namespace SQLite.Net.Async
         ///     not in ctor)
         /// </param>
         /// <param name="taskCreationOptions">Defaults to DenyChildAttach</param>
-        public AsyncTableQuery(TableQuery<T> innerQuery, TaskScheduler taskScheduler = null, TaskCreationOptions taskCreationOptions = TaskCreationOptions.None)
+        [PublicAPI]
+        public AsyncTableQuery([NotNull] TableQuery<T> innerQuery, [CanBeNull] TaskScheduler taskScheduler = null,
+            TaskCreationOptions taskCreationOptions = TaskCreationOptions.None)
         {
             if (innerQuery == null)
             {
@@ -53,7 +56,8 @@ namespace SQLite.Net.Async
             _taskCreationOptions = taskCreationOptions;
         }
 
-        public AsyncTableQuery<T> Where(Expression<Func<T, bool>> predExpr)
+        [PublicAPI]
+        public AsyncTableQuery<T> Where([NotNull] Expression<Func<T, bool>> predExpr)
         {
             if (predExpr == null)
             {
@@ -62,17 +66,20 @@ namespace SQLite.Net.Async
             return new AsyncTableQuery<T>(_innerQuery.Where(predExpr), _taskScheduler ?? TaskScheduler.Default, _taskCreationOptions);
         }
 
+        [PublicAPI]
         public AsyncTableQuery<T> Skip(int n)
         {
             return new AsyncTableQuery<T>(_innerQuery.Skip(n), _taskScheduler ?? TaskScheduler.Default, _taskCreationOptions);
         }
 
+        [PublicAPI]
         public AsyncTableQuery<T> Take(int n)
         {
             return new AsyncTableQuery<T>(_innerQuery.Take(n), _taskScheduler ?? TaskScheduler.Default, _taskCreationOptions);
         }
 
-        public AsyncTableQuery<T> OrderBy<TValue>(Expression<Func<T, TValue>> orderExpr)
+        [PublicAPI]
+        public AsyncTableQuery<T> OrderBy<TValue>([NotNull] Expression<Func<T, TValue>> orderExpr)
         {
             if (orderExpr == null)
             {
@@ -81,7 +88,8 @@ namespace SQLite.Net.Async
             return new AsyncTableQuery<T>(_innerQuery.OrderBy(orderExpr), _taskScheduler ?? TaskScheduler.Default, _taskCreationOptions);
         }
 
-        public AsyncTableQuery<T> OrderByDescending<TValue>(Expression<Func<T, TValue>> orderExpr)
+        [PublicAPI]
+        public AsyncTableQuery<T> OrderByDescending<TValue>([NotNull] Expression<Func<T, TValue>> orderExpr)
         {
             if (orderExpr == null)
             {
@@ -90,7 +98,8 @@ namespace SQLite.Net.Async
             return new AsyncTableQuery<T>(_innerQuery.OrderByDescending(orderExpr), _taskScheduler ?? TaskScheduler.Default, _taskCreationOptions);
         }
 
-        public AsyncTableQuery<T> ThenBy<TValue>(Expression<Func<T, TValue>> orderExpr)
+        [PublicAPI]
+        public AsyncTableQuery<T> ThenBy<TValue>([NotNull] Expression<Func<T, TValue>> orderExpr)
         {
             if (orderExpr == null)
             {
@@ -99,7 +108,8 @@ namespace SQLite.Net.Async
             return new AsyncTableQuery<T>(_innerQuery.ThenBy(orderExpr), _taskScheduler ?? TaskScheduler.Default, _taskCreationOptions);
         }
 
-        public AsyncTableQuery<T> ThenByDescending<TValue>(Expression<Func<T, TValue>> orderExpr)
+        [PublicAPI]
+        public AsyncTableQuery<T> ThenByDescending<TValue>([NotNull] Expression<Func<T, TValue>> orderExpr)
         {
             if (orderExpr == null)
             {
@@ -108,6 +118,7 @@ namespace SQLite.Net.Async
             return new AsyncTableQuery<T>(_innerQuery.ThenByDescending(orderExpr), _taskScheduler ?? TaskScheduler.Default, _taskCreationOptions);
         }
 
+        [PublicAPI]
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.Factory.StartNew(() =>
@@ -120,6 +131,7 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
+        [PublicAPI]
         public Task<int> CountAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.Factory.StartNew(() =>
@@ -132,6 +144,7 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
+        [PublicAPI]
         public Task<T> ElementAtAsync(int index, CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.Factory.StartNew(() =>
@@ -144,6 +157,7 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
+        [PublicAPI]
         public Task<T> FirstAsync(CancellationToken cancellationToken = default (CancellationToken))
         {
             return Task.Factory.StartNew(() =>
@@ -157,6 +171,7 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
+        [PublicAPI]
         public Task<T> FirstOrDefaultAsync(CancellationToken cancellationToken = default (CancellationToken))
         {
             return Task.Factory.StartNew(() =>

--- a/src/SQLite.Net.Async/SQLite.Net.Async.csproj
+++ b/src/SQLite.Net.Async/SQLite.Net.Async.csproj
@@ -27,7 +27,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;JETBRAINS_ANNOTATIONS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -35,7 +35,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;JETBRAINS_ANNOTATIONS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/SQLite.Net.Async/SQLite.Net.Async.csproj
+++ b/src/SQLite.Net.Async/SQLite.Net.Async.csproj
@@ -40,6 +40,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations.PCL328">
+      <HintPath>..\..\packages\JetBrains.Annotations.8.0.5.0\lib\portable-net4+sl5+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\JetBrains.Annotations.PCL328.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
@@ -57,6 +60,9 @@
       <Project>{4971D437-0694-4297-A8CC-146CE08C3BD9}</Project>
       <Name>SQLite.Net</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/src/SQLite.Net.Async/SQLiteAsyncConnection.cs
+++ b/src/SQLite.Net.Async/SQLiteAsyncConnection.cs
@@ -25,14 +25,15 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 
 namespace SQLite.Net.Async
 {
     public class SQLiteAsyncConnection
     {
-        private readonly Func<SQLiteConnectionWithLock> _sqliteConnectionFunc;
-        private readonly TaskCreationOptions _taskCreationOptions = TaskCreationOptions.None;
-        private readonly TaskScheduler _taskScheduler;
+        [NotNull] private readonly Func<SQLiteConnectionWithLock> _sqliteConnectionFunc;
+        private readonly TaskCreationOptions _taskCreationOptions;
+        [CanBeNull] private readonly TaskScheduler _taskScheduler;
 
         /// <summary>
         ///     Create a new async connection
@@ -43,7 +44,9 @@ namespace SQLite.Net.Async
         ///     not in ctor)
         /// </param>
         /// <param name="taskCreationOptions">Defaults to DenyChildAttach</param>
-        public SQLiteAsyncConnection(Func<SQLiteConnectionWithLock> sqliteConnectionFunc, TaskScheduler taskScheduler = null,
+        [PublicAPI]
+        public SQLiteAsyncConnection(
+            [NotNull] Func<SQLiteConnectionWithLock> sqliteConnectionFunc, [CanBeNull] TaskScheduler taskScheduler = null,
             TaskCreationOptions taskCreationOptions = TaskCreationOptions.None)
         {
             _sqliteConnectionFunc = sqliteConnectionFunc;
@@ -51,17 +54,20 @@ namespace SQLite.Net.Async
             _taskScheduler = taskScheduler;
         }
 
+        [PublicAPI]
         protected SQLiteConnectionWithLock GetConnection()
         {
             return _sqliteConnectionFunc();
         }
 
+        [PublicAPI]
         public Task<CreateTablesResult> CreateTableAsync<T>(CancellationToken cancellationToken = default (CancellationToken))
             where T : class
         {
             return CreateTablesAsync(cancellationToken, typeof (T));
         }
 
+        [PublicAPI]
         public Task<CreateTablesResult> CreateTablesAsync<T, T2>(CancellationToken cancellationToken = default (CancellationToken))
             where T : class
             where T2 : class
@@ -69,6 +75,7 @@ namespace SQLite.Net.Async
             return CreateTablesAsync(cancellationToken, typeof (T), typeof (T2));
         }
 
+        [PublicAPI]
         public Task<CreateTablesResult> CreateTablesAsync<T, T2, T3>(CancellationToken cancellationToken = default (CancellationToken))
             where T : class
             where T2 : class
@@ -77,6 +84,7 @@ namespace SQLite.Net.Async
             return CreateTablesAsync(cancellationToken, typeof (T), typeof (T2), typeof (T3));
         }
 
+        [PublicAPI]
         public Task<CreateTablesResult> CreateTablesAsync<T, T2, T3, T4>(CancellationToken cancellationToken = default (CancellationToken))
             where T : class
             where T2 : class
@@ -86,6 +94,7 @@ namespace SQLite.Net.Async
             return CreateTablesAsync(cancellationToken, typeof (T), typeof (T2), typeof (T3), typeof (T4));
         }
 
+        [PublicAPI]
         public Task<CreateTablesResult> CreateTablesAsync<T, T2, T3, T4, T5>(CancellationToken cancellationToken = default (CancellationToken))
             where T : class
             where T2 : class
@@ -96,12 +105,18 @@ namespace SQLite.Net.Async
             return CreateTablesAsync(cancellationToken, typeof (T), typeof (T2), typeof (T3), typeof (T4), typeof (T5));
         }
 
-        public Task<CreateTablesResult> CreateTablesAsync(params Type[] types)
+        [PublicAPI]
+        public Task<CreateTablesResult> CreateTablesAsync([NotNull] params Type[] types)
         {
+            if (types == null)
+            {
+                throw new ArgumentNullException("types");
+            }
             return CreateTablesAsync(CancellationToken.None, types);
         }
 
-        public Task<CreateTablesResult> CreateTablesAsync(CancellationToken cancellationToken, params Type[] types)
+        [PublicAPI]
+        public Task<CreateTablesResult> CreateTablesAsync(CancellationToken cancellationToken = default(CancellationToken), [NotNull] params Type[] types)
         {
             if (types == null)
             {
@@ -123,6 +138,7 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
+        [PublicAPI]
         public Task<int> DropTableAsync<T>(CancellationToken cancellationToken = default (CancellationToken))
             where T : class
         {
@@ -136,7 +152,8 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-        public Task<int> InsertAsync(object item, CancellationToken cancellationToken = default (CancellationToken))
+        [PublicAPI]
+        public Task<int> InsertAsync([NotNull] object item, CancellationToken cancellationToken = default (CancellationToken))
         {
             if (item == null)
             {
@@ -152,7 +169,8 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-        public Task<int> UpdateAsync(object item, CancellationToken cancellationToken = default (CancellationToken))
+        [PublicAPI]
+        public Task<int> UpdateAsync([NotNull] object item, CancellationToken cancellationToken = default (CancellationToken))
         {
             if (item == null)
             {
@@ -168,7 +186,8 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-        public Task<int> InsertOrReplaceAsync(object item, CancellationToken cancellationToken = default (CancellationToken))
+        [PublicAPI]
+        public Task<int> InsertOrReplaceAsync([NotNull] object item, CancellationToken cancellationToken = default (CancellationToken))
         {
             if (item == null)
             {
@@ -184,7 +203,8 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-        public Task<int> DeleteAsync(object item, CancellationToken cancellationToken = default (CancellationToken))
+        [PublicAPI]
+        public Task<int> DeleteAsync([NotNull] object item, CancellationToken cancellationToken = default (CancellationToken))
         {
             if (item == null)
             {
@@ -200,6 +220,7 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
+        [PublicAPI]
         public Task<int> DeleteAllAsync<T>(CancellationToken cancellationToken = default (CancellationToken))
         {
             return Task.Factory.StartNew(() =>
@@ -212,7 +233,8 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-        public Task<int> DeleteAsync<T>(object pk, CancellationToken cancellationToken = default (CancellationToken))
+        [PublicAPI]
+        public Task<int> DeleteAsync<T>([NotNull] object pk, CancellationToken cancellationToken = default (CancellationToken))
         {
             if (pk == null)
             {
@@ -228,7 +250,8 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-        public Task<T> GetAsync<T>(object pk, CancellationToken cancellationToken = default(CancellationToken))
+        [PublicAPI]
+        public Task<T> GetAsync<T>([NotNull] object pk, CancellationToken cancellationToken = default(CancellationToken))
             where T : class
         {
             if (pk == null)
@@ -247,7 +270,8 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-        public Task<T> FindAsync<T>(object pk, CancellationToken cancellationToken = default (CancellationToken))
+        [PublicAPI]
+        public Task<T> FindAsync<T>([NotNull] object pk, CancellationToken cancellationToken = default (CancellationToken))
             where T : class
         {
             if (pk == null)
@@ -266,7 +290,8 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-        public Task<T> GetAsync<T>(Expression<Func<T, bool>> predicate, CancellationToken cancellationToken = default (CancellationToken))
+        [PublicAPI]
+        public Task<T> GetAsync<T>([NotNull] Expression<Func<T, bool>> predicate, CancellationToken cancellationToken = default (CancellationToken))
             where T : class
         {
             if (predicate == null)
@@ -285,7 +310,8 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-        public Task<T> FindAsync<T>(Expression<Func<T, bool>> predicate, CancellationToken cancellationToken = default(CancellationToken))
+        [PublicAPI]
+        public Task<T> FindAsync<T>([NotNull] Expression<Func<T, bool>> predicate, CancellationToken cancellationToken = default(CancellationToken))
             where T : class
         {
             if (predicate == null)
@@ -304,12 +330,14 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-        public Task<int> ExecuteAsync(string query, params object[] args)
+        [PublicAPI]
+        public Task<int> ExecuteAsync([NotNull] string query, [NotNull] params object[] args)
         {
             return ExecuteAsync(CancellationToken.None, query, args);
         }
 
-        public Task<int> ExecuteAsync(CancellationToken cancellationToken, string query, params object[] args)
+        [PublicAPI]
+        public Task<int> ExecuteAsync(CancellationToken cancellationToken, [NotNull] string query, [NotNull] params object[] args)
         {
             if (query == null)
             {
@@ -329,7 +357,8 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-        public Task<int> InsertAllAsync(IEnumerable items, CancellationToken cancellationToken = default(CancellationToken))
+        [PublicAPI]
+        public Task<int> InsertAllAsync([NotNull] IEnumerable items, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (items == null)
             {
@@ -345,7 +374,8 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-        public Task<int> InsertOrReplaceAllAsync(IEnumerable items, CancellationToken cancellationToken = default(CancellationToken))
+        [PublicAPI]
+        public Task<int> InsertOrReplaceAllAsync([NotNull] IEnumerable items, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (items == null)
             {
@@ -361,7 +391,8 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-        public Task<int> UpdateAllAsync(IEnumerable items, CancellationToken cancellationToken = default(CancellationToken))
+        [PublicAPI]
+        public Task<int> UpdateAllAsync([NotNull] IEnumerable items, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (items == null)
             {
@@ -380,7 +411,8 @@ namespace SQLite.Net.Async
         [Obsolete(
             "Will cause a deadlock if any call in action ends up in a different thread. Use RunInTransactionAsync(Action<SQLiteConnection>) instead."
             )]
-        public Task RunInTransactionAsync(Action<SQLiteAsyncConnection> action, CancellationToken cancellationToken = default(CancellationToken))
+        [PublicAPI]
+        public Task RunInTransactionAsync([NotNull] Action<SQLiteAsyncConnection> action, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (action == null)
             {
@@ -406,7 +438,8 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-        public Task RunInTransactionAsync(Action<SQLiteConnection> action, CancellationToken cancellationToken = default(CancellationToken))
+        [PublicAPI]
+        public Task RunInTransactionAsync([NotNull] Action<SQLiteConnection> action, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (action == null)
             {
@@ -434,6 +467,7 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
+        [PublicAPI]
         public AsyncTableQuery<T> Table<T>()
             where T : class
         {
@@ -445,12 +479,14 @@ namespace SQLite.Net.Async
             return new AsyncTableQuery<T>(conn.Table<T>(), _taskScheduler, _taskCreationOptions);
         }
 
-        public Task<T> ExecuteScalarAsync<T>(string sql, params object[] args)
+        [PublicAPI]
+        public Task<T> ExecuteScalarAsync<T>([NotNull] string sql, [NotNull] params object[] args)
         {
             return ExecuteScalarAsync<T>(CancellationToken.None, sql, args);
         }
 
-        public Task<T> ExecuteScalarAsync<T>(CancellationToken cancellationToken, string sql, params object[] args)
+        [PublicAPI]
+        public Task<T> ExecuteScalarAsync<T>(CancellationToken cancellationToken, [NotNull] string sql, [NotNull] params object[] args)
         {
             if (sql == null)
             {
@@ -473,13 +509,15 @@ namespace SQLite.Net.Async
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }
 
-        public Task<List<T>> QueryAsync<T>(string sql, params object[] args)
+        [PublicAPI]
+        public Task<List<T>> QueryAsync<T>([NotNull] string sql, [NotNull] params object[] args)
             where T : class
         {
             return QueryAsync<T>(CancellationToken.None, sql, args);
         }
 
-        public Task<List<T>> QueryAsync<T>(CancellationToken cancellationToken, string sql, params object[] args)
+        [PublicAPI]
+        public Task<List<T>> QueryAsync<T>(CancellationToken cancellationToken, [NotNull] string sql, params object[] args)
             where T : class
         {
             if (sql == null)

--- a/src/SQLite.Net.Async/packages.config
+++ b/src/SQLite.Net.Async/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="JetBrains.Annotations" version="8.0.5.0" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
+</packages>

--- a/src/SQLite.Net/Attributes/AutoIncrementAttribute.cs
+++ b/src/SQLite.Net/Attributes/AutoIncrementAttribute.cs
@@ -21,9 +21,11 @@
 //
 
 using System;
+using JetBrains.Annotations;
 
 namespace SQLite.Net.Attributes
 {
+    [PublicAPI]
     [AttributeUsage(AttributeTargets.Property)]
     public class AutoIncrementAttribute : Attribute
     {

--- a/src/SQLite.Net/Attributes/CollationAttribute.cs
+++ b/src/SQLite.Net/Attributes/CollationAttribute.cs
@@ -21,9 +21,11 @@
 //
 
 using System;
+using JetBrains.Annotations;
 
 namespace SQLite.Net.Attributes
 {
+    [PublicAPI]
     [AttributeUsage(AttributeTargets.Property)]
     public class CollationAttribute : Attribute
     {

--- a/src/SQLite.Net/Attributes/ColumnAttribute.cs
+++ b/src/SQLite.Net/Attributes/ColumnAttribute.cs
@@ -21,9 +21,11 @@
 //
 
 using System;
+using JetBrains.Annotations;
 
 namespace SQLite.Net.Attributes
 {
+    [PublicAPI]
     [AttributeUsage(AttributeTargets.Property)]
     public class ColumnAttribute : Attribute
     {

--- a/src/SQLite.Net/Attributes/DefaultAttribute.cs
+++ b/src/SQLite.Net/Attributes/DefaultAttribute.cs
@@ -1,7 +1,9 @@
 using System;
+using JetBrains.Annotations;
 
 namespace SQLite.Net.Attributes
 {
+    [PublicAPI]
     [AttributeUsage(AttributeTargets.Property)]
     public class DefaultAttribute : Attribute
     {

--- a/src/SQLite.Net/Attributes/IgnoreAttribute.cs
+++ b/src/SQLite.Net/Attributes/IgnoreAttribute.cs
@@ -21,9 +21,11 @@
 //
 
 using System;
+using JetBrains.Annotations;
 
 namespace SQLite.Net.Attributes
 {
+    [PublicAPI]
     [AttributeUsage(AttributeTargets.Property)]
     public class IgnoreAttribute : Attribute
     {

--- a/src/SQLite.Net/Attributes/IndexedAttribute.cs
+++ b/src/SQLite.Net/Attributes/IndexedAttribute.cs
@@ -21,9 +21,11 @@
 //
 
 using System;
+using JetBrains.Annotations;
 
 namespace SQLite.Net.Attributes
 {
+    [PublicAPI]
     [AttributeUsage(AttributeTargets.Property)]
     public class IndexedAttribute : Attribute
     {

--- a/src/SQLite.Net/Attributes/MaxLengthAttribute.cs
+++ b/src/SQLite.Net/Attributes/MaxLengthAttribute.cs
@@ -21,9 +21,11 @@
 //
 
 using System;
+using JetBrains.Annotations;
 
 namespace SQLite.Net.Attributes
 {
+    [PublicAPI]
     [AttributeUsage(AttributeTargets.Property)]
     public class MaxLengthAttribute : Attribute
     {

--- a/src/SQLite.Net/Attributes/NotNullAttribute.cs
+++ b/src/SQLite.Net/Attributes/NotNullAttribute.cs
@@ -22,9 +22,11 @@
 //
 
 using System;
+using JetBrains.Annotations;
 
 namespace SQLite.Net.Attributes
 {
+    [PublicAPI]
     [AttributeUsage(AttributeTargets.Property)]
     public class NotNullAttribute : Attribute
     {

--- a/src/SQLite.Net/Attributes/PrimaryKeyAttribute.cs
+++ b/src/SQLite.Net/Attributes/PrimaryKeyAttribute.cs
@@ -21,9 +21,11 @@
 //
 
 using System;
+using JetBrains.Annotations;
 
 namespace SQLite.Net.Attributes
 {
+    [PublicAPI]
     [AttributeUsage(AttributeTargets.Property)]
     public class PrimaryKeyAttribute : Attribute
     {

--- a/src/SQLite.Net/Attributes/TableAttribute.cs
+++ b/src/SQLite.Net/Attributes/TableAttribute.cs
@@ -21,9 +21,11 @@
 //
 
 using System;
+using JetBrains.Annotations;
 
 namespace SQLite.Net.Attributes
 {
+    [PublicAPI]
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface)]
     public class TableAttribute : Attribute
     {

--- a/src/SQLite.Net/Attributes/UniqueAttribute.cs
+++ b/src/SQLite.Net/Attributes/UniqueAttribute.cs
@@ -21,9 +21,11 @@
 //
 
 using System;
+using JetBrains.Annotations;
 
 namespace SQLite.Net.Attributes
 {
+    [PublicAPI]
     [AttributeUsage(AttributeTargets.Property)]
     public class UniqueAttribute : IndexedAttribute
     {

--- a/src/SQLite.Net/BaseTableQuery.cs
+++ b/src/SQLite.Net/BaseTableQuery.cs
@@ -19,13 +19,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using JetBrains.Annotations;
+
 namespace SQLite.Net
 {
+    [PublicAPI]
     public abstract class BaseTableQuery
     {
         protected class Ordering
         {
+            [CanBeNull]
             public string ColumnName { get; set; }
+
             public bool Ascending { get; set; }
         }
     }

--- a/src/SQLite.Net/BlobSerializerDelegate.cs
+++ b/src/SQLite.Net/BlobSerializerDelegate.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 
 namespace SQLite.Net
 {
@@ -14,6 +15,7 @@ namespace SQLite.Net
         private readonly DeserializeDelegate _deserializeDelegate;
         private readonly SerializeDelegate _serializeDelegate;
 
+        [PublicAPI]
         public BlobSerializerDelegate(SerializeDelegate serializeDelegate,
             DeserializeDelegate deserializeDelegate,
             CanSerializeDelegate canDeserializeDelegate)
@@ -25,16 +27,19 @@ namespace SQLite.Net
 
         #region IBlobSerializer implementation
 
+        [PublicAPI]
         public byte[] Serialize<T>(T obj)
         {
             return _serializeDelegate(obj);
         }
 
+        [PublicAPI]
         public object Deserialize(byte[] data, Type type)
         {
             return _deserializeDelegate(data, type);
         }
 
+        [PublicAPI]
         public bool CanDeserialize(Type type)
         {
             return _canDeserializeDelegate(type);

--- a/src/SQLite.Net/ContractResolver.cs
+++ b/src/SQLite.Net/ContractResolver.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 
 namespace SQLite.Net
 {
@@ -23,6 +24,7 @@ namespace SQLite.Net
         ///     Default Initializer for a new instance of the <see cref="ContractResolver" /> class.
         ///     This constructor sets the resolver to the .NET Refection based Activator.CreateInstance method
         /// </summary>
+        [PublicAPI]
         public ContractResolver() : this(t => true, Activator.CreateInstance)
         {
         }
@@ -34,6 +36,7 @@ namespace SQLite.Net
         /// </summary>
         /// <param name="canCreate">The can create.</param>
         /// <param name="create">The create.</param>
+        [PublicAPI]
         public ContractResolver(Func<Type, bool> canCreate, Func<Type, object[], object> create)
         {
             if (canCreate == null)
@@ -53,6 +56,7 @@ namespace SQLite.Net
         ///     behavior of the library prior to the addition of this functionality
         /// </summary>
         /// <value>The current.</value>
+        [PublicAPI]
         public static ContractResolver Current
         {
             get { return _current ?? (_current = new ContractResolver()); }
@@ -66,6 +70,7 @@ namespace SQLite.Net
         ///     Returns true if the type can be resolved.  Note, if the default constructor is used, this will always return
         ///     true
         /// </value>
+        [PublicAPI]
         public Func<Type, bool> CanCreate
         {
             get { return _canCreate; }
@@ -78,6 +83,7 @@ namespace SQLite.Net
         ///     if the resolve supports it.
         /// </summary>
         /// <value>The create.</value>
+        [PublicAPI]
         public Func<Type, object[], object> Create
         {
             get { return _create; }
@@ -89,6 +95,7 @@ namespace SQLite.Net
         /// <param name="type">The type.</param>
         /// <param name="constructorArgs">The constructor arguments.</param>
         /// <returns>System.Object.</returns>
+        [PublicAPI]
         public object CreateObject(Type type, object[] constructorArgs = null)
         {
             if (CanCreate == null || CanCreate(type))

--- a/src/SQLite.Net/CreateTablesResult.cs
+++ b/src/SQLite.Net/CreateTablesResult.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 
 namespace SQLite.Net
 {
@@ -31,6 +32,8 @@ namespace SQLite.Net
             Results = new Dictionary<Type, int>();
         }
 
+        [NotNull]
+        [PublicAPI]
         public Dictionary<Type, int> Results { get; private set; }
     }
 }

--- a/src/SQLite.Net/IBlobSerializer.cs
+++ b/src/SQLite.Net/IBlobSerializer.cs
@@ -15,6 +15,7 @@
 //
 
 using System;
+using JetBrains.Annotations;
 
 namespace SQLite.Net
 {
@@ -28,6 +29,7 @@ namespace SQLite.Net
         /// </summary>
         /// <param name="obj">Object to serialize</param>
         /// <returns>Serialized blob of the object</returns>
+        [PublicAPI]
         byte[] Serialize<T>(T obj);
 
         /// <summary>
@@ -36,8 +38,10 @@ namespace SQLite.Net
         /// <param name="data">Serialized object</param>
         /// <param name="type">Type of object</param>
         /// <returns>Deserialized object</returns>
+        [PublicAPI]
         object Deserialize(byte[] data, Type type);
 
+        [PublicAPI]
         bool CanDeserialize(Type type);
     }
 }

--- a/src/SQLite.Net/IContractResolver.cs
+++ b/src/SQLite.Net/IContractResolver.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 
 namespace SQLite.Net
 {
@@ -17,6 +18,7 @@ namespace SQLite.Net
         ///     Returns true if the type can be resolved.  Note, if the default constructor is used, this will always return
         ///     true
         /// </value>
+        [PublicAPI]
         Func<Type, bool> CanCreate { get; }
 
         /// <summary>
@@ -26,6 +28,7 @@ namespace SQLite.Net
         ///     if the resolve supports it.
         /// </summary>
         /// <value>The create.</value>
+        [PublicAPI]
         Func<Type, object[], object> Create { get; }
 
         /// <summary>
@@ -34,6 +37,7 @@ namespace SQLite.Net
         /// <param name="type">The type.</param>
         /// <param name="constructorArgs">The constructor arguments.</param>
         /// <returns>System.Object.</returns>
+        [PublicAPI]
         object CreateObject(Type type, object[] constructorArgs = null);
     }
 }

--- a/src/SQLite.Net/ISerializable.cs
+++ b/src/SQLite.Net/ISerializable.cs
@@ -1,7 +1,10 @@
-﻿namespace SQLite.Net
+﻿using JetBrains.Annotations;
+
+namespace SQLite.Net
 {
     public interface ISerializable<T>
     {
+        [PublicAPI]
         T Serialize();
     }
 }

--- a/src/SQLite.Net/ITraceListener.cs
+++ b/src/SQLite.Net/ITraceListener.cs
@@ -1,7 +1,10 @@
-﻿namespace SQLite.Net
+﻿using JetBrains.Annotations;
+
+namespace SQLite.Net
 {
     public interface ITraceListener
     {
+        [PublicAPI]
         void Receive(string message);
     }
 }

--- a/src/SQLite.Net/Interop/ColType.cs
+++ b/src/SQLite.Net/Interop/ColType.cs
@@ -20,8 +20,11 @@
 // THE SOFTWARE.
 //
 
+using JetBrains.Annotations;
+
 namespace SQLite.Net.Interop
 {
+    [PublicAPI]
     public enum ColType
     {
         Integer = 1,

--- a/src/SQLite.Net/Interop/ConfigOption.cs
+++ b/src/SQLite.Net/Interop/ConfigOption.cs
@@ -20,8 +20,11 @@
 // THE SOFTWARE.
 //
 
+using JetBrains.Annotations;
+
 namespace SQLite.Net.Interop
 {
+    [PublicAPI]
     public enum ConfigOption
     {
         SingleThread = 1,

--- a/src/SQLite.Net/Interop/CreateFlags.cs
+++ b/src/SQLite.Net/Interop/CreateFlags.cs
@@ -21,9 +21,11 @@
 //
 
 using System;
+using JetBrains.Annotations;
 
 namespace SQLite.Net.Interop
 {
+    [PublicAPI]
     [Flags]
     public enum CreateFlags
     {

--- a/src/SQLite.Net/Interop/ExtendedResult.cs
+++ b/src/SQLite.Net/Interop/ExtendedResult.cs
@@ -1,5 +1,8 @@
+using JetBrains.Annotations;
+
 namespace SQLite.Net.Interop
 {
+    [PublicAPI]
     public enum ExtendedResult
     {
         IOErrorRead = (Result.IOError | (1 << 8)),

--- a/src/SQLite.Net/Interop/IDbHandle.cs
+++ b/src/SQLite.Net/Interop/IDbHandle.cs
@@ -20,8 +20,11 @@
 // THE SOFTWARE.
 //
 
+using JetBrains.Annotations;
+
 namespace SQLite.Net.Interop
 {
+    [PublicAPI]
     public interface IDbHandle
     {
     }

--- a/src/SQLite.Net/Interop/IDbStatement.cs
+++ b/src/SQLite.Net/Interop/IDbStatement.cs
@@ -20,8 +20,11 @@
 // THE SOFTWARE.
 //
 
+using JetBrains.Annotations;
+
 namespace SQLite.Net.Interop
 {
+    [PublicAPI]
     public interface IDbStatement
     {
     }

--- a/src/SQLite.Net/Interop/IReflectionService.cs
+++ b/src/SQLite.Net/Interop/IReflectionService.cs
@@ -23,9 +23,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
+using JetBrains.Annotations;
 
 namespace SQLite.Net.Interop
 {
+    [PublicAPI]
     public interface IReflectionService
     {
         IEnumerable<PropertyInfo> GetPublicInstanceProperties(Type mappedType);

--- a/src/SQLite.Net/Interop/ISQLiteApi.cs
+++ b/src/SQLite.Net/Interop/ISQLiteApi.cs
@@ -20,9 +20,11 @@
 // THE SOFTWARE.
 
 using System;
+using JetBrains.Annotations;
 
 namespace SQLite.Net.Interop
 {
+    [PublicAPI]
     public interface ISQLiteApi
     {
         Result Open(byte[] filename, out IDbHandle db, int flags, IntPtr zvfs);

--- a/src/SQLite.Net/Interop/ISQLitePlatform.cs
+++ b/src/SQLite.Net/Interop/ISQLitePlatform.cs
@@ -19,8 +19,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using JetBrains.Annotations;
+
 namespace SQLite.Net.Interop
 {
+    [PublicAPI]
     public interface ISQLitePlatform
     {
         ISQLiteApi SQLiteApi { get; }

--- a/src/SQLite.Net/Interop/IStopwatch.cs
+++ b/src/SQLite.Net/Interop/IStopwatch.cs
@@ -19,8 +19,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using JetBrains.Annotations;
+
 namespace SQLite.Net.Interop
 {
+    [PublicAPI]
     public interface IStopwatch
     {
         long ElapsedMilliseconds { get; }

--- a/src/SQLite.Net/Interop/IStopwatchFactory.cs
+++ b/src/SQLite.Net/Interop/IStopwatchFactory.cs
@@ -19,8 +19,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using JetBrains.Annotations;
+
 namespace SQLite.Net.Interop
 {
+    [PublicAPI]
     public interface IStopwatchFactory
     {
         IStopwatch Create();

--- a/src/SQLite.Net/Interop/IVolatileService.cs
+++ b/src/SQLite.Net/Interop/IVolatileService.cs
@@ -19,8 +19,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using JetBrains.Annotations;
+
 namespace SQLite.Net.Interop
 {
+    [PublicAPI]
     public interface IVolatileService
     {
         void Write(ref int transactionDepth, int depth);

--- a/src/SQLite.Net/Interop/Result.cs
+++ b/src/SQLite.Net/Interop/Result.cs
@@ -1,5 +1,8 @@
+using JetBrains.Annotations;
+
 namespace SQLite.Net.Interop
 {
+    [PublicAPI]
     public enum Result
     {
         OK = 0,

--- a/src/SQLite.Net/Interop/SQLiteOpenFlags.cs
+++ b/src/SQLite.Net/Interop/SQLiteOpenFlags.cs
@@ -21,9 +21,11 @@
 //
 
 using System;
+using JetBrains.Annotations;
 
 namespace SQLite.Net.Interop
 {
+    [PublicAPI]
     [Flags]
     public enum SQLiteOpenFlags
     {

--- a/src/SQLite.Net/NotNullConstraintViolationException.cs
+++ b/src/SQLite.Net/NotNullConstraintViolationException.cs
@@ -22,10 +22,12 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
 using SQLite.Net.Interop;
 
 namespace SQLite.Net
 {
+    [PublicAPI]
     public class NotNullConstraintViolationException : SQLiteException
     {
         protected NotNullConstraintViolationException(Result r, string message, TableMapping mapping = null, object obj = null)
@@ -39,6 +41,7 @@ namespace SQLite.Net
             }
         }
 
+        [PublicAPI]
         public IEnumerable<TableMapping.Column> Columns { get; protected set; }
 
         internal new static NotNullConstraintViolationException New(Result r, string message)

--- a/src/SQLite.Net/Orm.cs
+++ b/src/SQLite.Net/Orm.cs
@@ -25,7 +25,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using JetBrains.Annotations;
 using SQLite.Net.Attributes;
+using NotNullAttribute = SQLite.Net.Attributes.NotNullAttribute;
 
 namespace SQLite.Net
 {
@@ -167,6 +169,7 @@ namespace SQLite.Net
             return p.GetCustomAttributes<IndexedAttribute>();
         }
 
+        [CanBeNull]
         internal static int? MaxStringLength(PropertyInfo p)
         {
             foreach (var attribute in p.CustomAttributes.Where(a => a.AttributeType == typeof (MaxLengthAttribute)))
@@ -176,6 +179,7 @@ namespace SQLite.Net
             return null;
         }
 
+        [CanBeNull]
         internal static object GetDefaultValue(PropertyInfo p)
         {
             foreach (var attribute in p.GetCustomAttributes<DefaultAttribute>())

--- a/src/SQLite.Net/PreparedSqlLiteInsertCommand.cs
+++ b/src/SQLite.Net/PreparedSqlLiteInsertCommand.cs
@@ -22,6 +22,7 @@
 //
 
 using System;
+using JetBrains.Annotations;
 using SQLite.Net.Interop;
 
 namespace SQLite.Net
@@ -38,11 +39,19 @@ namespace SQLite.Net
             Connection = conn;
         }
 
+        [PublicAPI]
         public bool Initialized { get; set; }
+
+        [PublicAPI]
         public string CommandText { get; set; }
+
+        [PublicAPI]
         protected SQLiteConnection Connection { get; set; }
+
+        [PublicAPI]
         protected IDbStatement Statement { get; set; }
 
+        [PublicAPI]
         public void Dispose()
         {
             Dispose(true);
@@ -54,6 +63,7 @@ namespace SQLite.Net
             Dispose(false);
         }
 
+        [PublicAPI]
         public int ExecuteNonQuery(object[] source)
         {
             Connection.TraceListener.WriteLine("Executing: {0}", CommandText);
@@ -99,6 +109,7 @@ namespace SQLite.Net
             throw SQLiteException.New(r, r.ToString());
         }
 
+        [PublicAPI]
         protected virtual IDbStatement Prepare()
         {
             var stmt = Connection.Platform.SQLiteApi.Prepare2(Connection.Handle, CommandText);

--- a/src/SQLite.Net/SQLite.Net.csproj
+++ b/src/SQLite.Net/SQLite.Net.csproj
@@ -43,7 +43,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;JETBRAINS_ANNOTATIONS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -51,7 +51,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;JETBRAINS_ANNOTATIONS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/SQLite.Net/SQLite.Net.csproj
+++ b/src/SQLite.Net/SQLite.Net.csproj
@@ -35,6 +35,8 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -54,6 +56,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="JetBrains.Annotations.PCL328">
+      <HintPath>..\..\packages\JetBrains.Annotations.8.0.5.0\lib\portable-net4+sl5+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\JetBrains.Annotations.PCL328.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
@@ -123,8 +129,11 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/SQLite.Net/SQLiteCommand.cs
+++ b/src/SQLite.Net/SQLiteCommand.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using JetBrains.Annotations;
 using SQLite.Net.Interop;
 
 namespace SQLite.Net
@@ -32,7 +33,10 @@ namespace SQLite.Net
     public class SQLiteCommand
     {
         internal static IntPtr NegativePointer = new IntPtr(-1);
+
+        [NotNull]
         private readonly List<Binding> _bindings;
+
         private readonly SQLiteConnection _conn;
         private readonly ISQLitePlatform _sqlitePlatform;
 
@@ -44,8 +48,10 @@ namespace SQLite.Net
             CommandText = "";
         }
 
+        [PublicAPI]
         public string CommandText { get; set; }
 
+        [PublicAPI]
         public int ExecuteNonQuery()
         {
             _conn.TraceListener.WriteLine("Executing: {0}", this);
@@ -74,16 +80,19 @@ namespace SQLite.Net
             throw SQLiteException.New(r, r.ToString());
         }
 
+        [PublicAPI]
         public IEnumerable<T> ExecuteDeferredQuery<T>()
         {
             return ExecuteDeferredQuery<T>(_conn.GetMapping(typeof (T)));
         }
 
+        [PublicAPI]
         public List<T> ExecuteQuery<T>()
         {
             return ExecuteDeferredQuery<T>(_conn.GetMapping(typeof (T))).ToList();
         }
 
+        [PublicAPI]
         public List<T> ExecuteQuery<T>(TableMapping map)
         {
             return ExecuteDeferredQuery<T>(map).ToList();
@@ -100,11 +109,13 @@ namespace SQLite.Net
         ///     method to hook into the life-cycle of objects.
         ///     Type safety is not possible because MonoTouch does not support virtual generic methods.
         /// </remarks>
+        [PublicAPI]
         protected virtual void OnInstanceCreated(object obj)
         {
             // Can be overridden.
         }
 
+        [PublicAPI]
         public IEnumerable<T> ExecuteDeferredQuery<T>(TableMapping map)
         {
             _conn.TraceListener.WriteLine("Executing Query: {0}", this);
@@ -143,6 +154,8 @@ namespace SQLite.Net
             }
         }
 
+        [PublicAPI]
+        [CanBeNull]
         public T ExecuteScalar<T>()
         {
             _conn.TraceListener.WriteLine("Executing Query: {0}", this);
@@ -179,7 +192,8 @@ namespace SQLite.Net
             return val;
         }
 
-        public void Bind(string name, object val)
+        [PublicAPI]
+        public void Bind([CanBeNull] string name, [CanBeNull] object val)
         {
             _bindings.Add(new Binding
             {
@@ -188,11 +202,13 @@ namespace SQLite.Net
             });
         }
 
+        [PublicAPI]
         public void Bind(object val)
         {
             Bind(null, val);
         }
 
+        [PublicAPI]
         public override string ToString()
         {
             var parts = new string[1 + _bindings.Count];
@@ -382,6 +398,7 @@ namespace SQLite.Net
             }
         }
 
+        [CanBeNull]
         private object ReadCol(IDbStatement stmt, int index, ColType type, Type clrType)
         {
             var interfaces = clrType.GetTypeInfo().ImplementedInterfaces.ToList();
@@ -564,8 +581,12 @@ namespace SQLite.Net
 
         private class Binding
         {
+            [CanBeNull]
             public string Name { get; set; }
+
+            [CanBeNull]
             public object Value { get; set; }
+
             public int Index { get; set; }
         }
     }

--- a/src/SQLite.Net/SQLiteConnectionPool.cs
+++ b/src/SQLite.Net/SQLiteConnectionPool.cs
@@ -22,6 +22,7 @@
 //
 
 using System.Collections.Generic;
+using JetBrains.Annotations;
 using SQLite.Net.Interop;
 
 namespace SQLite.Net
@@ -32,11 +33,13 @@ namespace SQLite.Net
         private readonly object _entriesLock = new object();
         private readonly ISQLitePlatform _sqlitePlatform;
 
+        [PublicAPI]
         public SQLiteConnectionPool(ISQLitePlatform sqlitePlatform)
         {
             _sqlitePlatform = sqlitePlatform;
         }
 
+        [PublicAPI]
         public SQLiteConnectionWithLock GetConnection(SQLiteConnectionString connectionString)
         {
             lock (_entriesLock)
@@ -57,6 +60,7 @@ namespace SQLite.Net
         /// <summary>
         ///     Closes all connections managed by this pool.
         /// </summary>
+        [PublicAPI]
         public void Reset()
         {
             lock (_entriesLock)
@@ -73,6 +77,7 @@ namespace SQLite.Net
         ///     Call this method when the application is suspended.
         /// </summary>
         /// <remarks>Behaviour here is to close any open connections.</remarks>
+        [PublicAPI]
         public void ApplicationSuspended()
         {
             Reset();

--- a/src/SQLite.Net/SQLiteConnectionString.cs
+++ b/src/SQLite.Net/SQLiteConnectionString.cs
@@ -21,6 +21,8 @@
 // THE SOFTWARE.
 //
 
+using JetBrains.Annotations;
+
 namespace SQLite.Net
 {
     /// <summary>
@@ -28,6 +30,7 @@ namespace SQLite.Net
     /// </summary>
     public class SQLiteConnectionString
     {
+        [PublicAPI]
         public SQLiteConnectionString(string databasePath, bool storeDateTimeAsTicks,
             IBlobSerializer serializer = null,
             IContractResolver resolver = null)
@@ -40,10 +43,19 @@ namespace SQLite.Net
             Resolver = resolver ?? ContractResolver.Current;
         }
 
+        [PublicAPI]
         public string ConnectionString { get; private set; }
+
+        [PublicAPI]
         public string DatabasePath { get; private set; }
+
+        [PublicAPI]
         public bool StoreDateTimeAsTicks { get; private set; }
+
+        [PublicAPI]
         public IBlobSerializer Serializer { get; private set; }
+
+        [PublicAPI]
         public IContractResolver Resolver { get; private set; }
     }
 }

--- a/src/SQLite.Net/SQLiteConnectionWithLock.cs
+++ b/src/SQLite.Net/SQLiteConnectionWithLock.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Threading;
+using JetBrains.Annotations;
 using SQLite.Net.Interop;
 
 namespace SQLite.Net
@@ -30,9 +31,11 @@ namespace SQLite.Net
     {
         private readonly object _lockPoint = new object();
 
+        [PublicAPI]
         public SQLiteConnectionWithLock(ISQLitePlatform sqlitePlatform, SQLiteConnectionString connectionString)
             : base(sqlitePlatform, connectionString.DatabasePath, connectionString.StoreDateTimeAsTicks, connectionString.Serializer, null, null, connectionString.Resolver) { }
 
+        [PublicAPI]
         public IDisposable Lock()
         {
             return new LockWrapper(_lockPoint);

--- a/src/SQLite.Net/SQLiteException.cs
+++ b/src/SQLite.Net/SQLiteException.cs
@@ -21,10 +21,12 @@
 // THE SOFTWARE.
 
 using System;
+using JetBrains.Annotations;
 using SQLite.Net.Interop;
 
 namespace SQLite.Net
 {
+    [PublicAPI]
     public class SQLiteException : Exception
     {
         protected SQLiteException(Result r, string message) : base(message)
@@ -32,8 +34,10 @@ namespace SQLite.Net
             Result = r;
         }
 
+        [PublicAPI]
         public Result Result { get; private set; }
 
+        [PublicAPI]
         public static SQLiteException New(Result r, string message)
         {
             return new SQLiteException(r, message);

--- a/src/SQLite.Net/TableMapping.cs
+++ b/src/SQLite.Net/TableMapping.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using JetBrains.Annotations;
 using SQLite.Net.Attributes;
 using SQLite.Net.Interop;
 
@@ -33,7 +34,7 @@ namespace SQLite.Net
     {
         private readonly Column _autoPk;
         private Column[] _insertColumns;
-
+        [PublicAPI]
         public TableMapping(Type type, IEnumerable<PropertyInfo> properties, CreateFlags createFlags = CreateFlags.None)
         {
             MappedType = type;
@@ -80,18 +81,31 @@ namespace SQLite.Net
             }
         }
 
+        [PublicAPI]
         public Type MappedType { get; private set; }
+
+        [PublicAPI]
         public string TableName { get; private set; }
+
+        [PublicAPI]
         public Column[] Columns { get; private set; }
+
+        [PublicAPI]
         public Column PK { get; private set; }
+
+        [PublicAPI]
         public string GetByPrimaryKeySql { get; private set; }
+
+        [PublicAPI]
         public bool HasAutoIncPK { get; private set; }
 
+        [PublicAPI]
         public Column[] InsertColumns
         {
             get { return _insertColumns ?? (_insertColumns = Columns.Where(c => !c.IsAutoInc).ToArray()); }
         }
 
+        [PublicAPI]
         public void SetAutoIncPK(object obj, long id)
         {
             if (_autoPk != null)
@@ -100,12 +114,14 @@ namespace SQLite.Net
             }
         }
 
+        [PublicAPI]
         public Column FindColumnWithPropertyName(string propertyName)
         {
             var exact = Columns.FirstOrDefault(c => c.PropertyName == propertyName);
             return exact;
         }
 
+        [PublicAPI]
         public Column FindColumn(string columnName)
         {
             var exact = Columns.FirstOrDefault(c => c.Name == columnName);
@@ -116,6 +132,7 @@ namespace SQLite.Net
         {
             private readonly PropertyInfo _prop;
 
+            [PublicAPI]
             public Column(PropertyInfo prop, CreateFlags createFlags = CreateFlags.None)
             {
                 var colAttr =
@@ -150,21 +167,40 @@ namespace SQLite.Net
                 MaxStringLength = Orm.MaxStringLength(prop);
             }
 
+            [PublicAPI]
             public string Name { get; private set; }
 
+            [PublicAPI]
             public string PropertyName
             {
                 get { return _prop.Name; }
             }
 
+            [PublicAPI]
             public Type ColumnType { get; private set; }
+
+            [PublicAPI]
             public string Collation { get; private set; }
+
+            [PublicAPI]
             public bool IsAutoInc { get; private set; }
+
+            [PublicAPI]
             public bool IsAutoGuid { get; private set; }
+
+            [PublicAPI]
             public bool IsPK { get; private set; }
+
+            [PublicAPI]
             public IEnumerable<IndexedAttribute> Indices { get; set; }
+
+            [PublicAPI]
             public bool IsNullable { get; private set; }
+
+            [PublicAPI]
             public int? MaxStringLength { get; private set; }
+
+            [PublicAPI]
             public object DefaultValue { get; private set; }
 
             /// <summary>
@@ -172,7 +208,8 @@ namespace SQLite.Net
             /// </summary>
             /// <param name="obj"></param>
             /// <param name="val"></param>
-            public void SetValue(object obj, object val)
+            [PublicAPI]
+            public void SetValue(object obj, [CanBeNull] object val)
             {
                 var propType = _prop.PropertyType;
                 var typeInfo = propType.GetTypeInfo();
@@ -207,6 +244,7 @@ namespace SQLite.Net
                 }
             }
 
+            [PublicAPI]
             public object GetValue(object obj)
             {
                 return _prop.GetValue(obj, null);

--- a/src/SQLite.Net/TableQuery.cs
+++ b/src/SQLite.Net/TableQuery.cs
@@ -27,6 +27,7 @@ using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
+using JetBrains.Annotations;
 using SQLite.Net.Interop;
 
 namespace SQLite.Net
@@ -53,6 +54,7 @@ namespace SQLite.Net
             Table = table;
         }
 
+        [PublicAPI]
         public TableQuery(ISQLitePlatform platformImplementation, SQLiteConnection conn)
         {
             _sqlitePlatform = platformImplementation;
@@ -60,9 +62,13 @@ namespace SQLite.Net
             Table = Connection.GetMapping(typeof (T));
         }
 
+        [PublicAPI]
         public SQLiteConnection Connection { get; private set; }
+
+        [PublicAPI]
         public TableMapping Table { get; private set; }
 
+        [PublicAPI]
         public IEnumerator<T> GetEnumerator()
         {
             if (!_deferred)
@@ -73,11 +79,13 @@ namespace SQLite.Net
             return GenerateCommand("*").ExecuteDeferredQuery<T>().GetEnumerator();
         }
 
+        [PublicAPI]
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
         }
 
+        [PublicAPI]
         public TableQuery<U> Clone<U>()
         {
             var q = new TableQuery<U>(_sqlitePlatform, Connection, Table);
@@ -98,6 +106,7 @@ namespace SQLite.Net
             return q;
         }
 
+        [PublicAPI]
         public TableQuery<T> Where(Expression<Func<T, bool>> predExpr)
         {
             if (predExpr.NodeType == ExpressionType.Lambda)
@@ -111,6 +120,7 @@ namespace SQLite.Net
             throw new NotSupportedException("Must be a predicate");
         }
 
+        [PublicAPI]
         public TableQuery<T> Take(int n)
         {
             var q = Clone<T>();
@@ -121,6 +131,7 @@ namespace SQLite.Net
             return q;
         }
 
+        [PublicAPI]
         public TableQuery<T> Skip(int n)
         {
             var q = Clone<T>();
@@ -129,11 +140,13 @@ namespace SQLite.Net
             return q;
         }
 
+        [PublicAPI]
         public T ElementAt(int index)
         {
             return Skip(index).Take(1).First();
         }
 
+        [PublicAPI]
         public TableQuery<T> Deferred()
         {
             var q = Clone<T>();
@@ -141,21 +154,25 @@ namespace SQLite.Net
             return q;
         }
 
+        [PublicAPI]
         public TableQuery<T> OrderBy<TValue>(Expression<Func<T, TValue>> orderExpr)
         {
             return AddOrderBy(orderExpr, true);
         }
 
+        [PublicAPI]
         public TableQuery<T> OrderByDescending<TValue>(Expression<Func<T, TValue>> orderExpr)
         {
             return AddOrderBy(orderExpr, false);
         }
 
+        [PublicAPI]
         public TableQuery<T> ThenBy<TValue>(Expression<Func<T, TValue>> orderExpr)
         {
             return AddOrderBy(orderExpr, true);
         }
 
+        [PublicAPI]
         public TableQuery<T> ThenByDescending<TValue>(Expression<Func<T, TValue>> orderExpr)
         {
             return AddOrderBy(orderExpr, false);
@@ -215,6 +232,7 @@ namespace SQLite.Net
             }
         }
 
+        [PublicAPI]
         public TableQuery<TResult> Join<TInner, TKey, TResult>(
             TableQuery<TInner> inner,
             Expression<Func<T, TKey>> outerKeySelector,
@@ -232,6 +250,7 @@ namespace SQLite.Net
             return q;
         }
 
+        [PublicAPI]
         public TableQuery<TResult> Select<TResult>(Expression<Func<T, TResult>> selector)
         {
             var q = Clone<TResult>();
@@ -456,6 +475,7 @@ namespace SQLite.Net
             throw new NotSupportedException("Cannot compile: " + expr.NodeType);
         }
 
+        [CanBeNull]
         private object ConvertTo(object obj, Type t)
         {
             var nut = Nullable.GetUnderlyingType(t);
@@ -536,22 +556,26 @@ namespace SQLite.Net
             throw new NotSupportedException("Cannot get SQL for: " + n);
         }
 
+        [PublicAPI]
         public int Count()
         {
             return GenerateCommand("count(*)").ExecuteScalar<int>();
         }
 
+        [PublicAPI]
         public int Count(Expression<Func<T, bool>> predExpr)
         {
             return Where(predExpr).Count();
         }
 
+        [PublicAPI]
         public T First()
         {
             var query = Take(1);
             return query.ToList().First();
         }
 
+        [PublicAPI]
         public T FirstOrDefault()
         {
             var query = Take(1);
@@ -561,6 +585,8 @@ namespace SQLite.Net
         private class CompileResult
         {
             public string CommandText { get; set; }
+
+            [CanBeNull]
             public object Value { get; set; }
         }
     }

--- a/src/SQLite.Net/TraceListenerExtensions.cs
+++ b/src/SQLite.Net/TraceListenerExtensions.cs
@@ -1,9 +1,11 @@
 ﻿using System.Globalization;
+using JetBrains.Annotations;
 
 namespace SQLite.Net
 {
     public static class TraceListenerExtensions
     {
+        [PublicAPI]
         public static void WriteLine(this ITraceListener @this, string message)
         {
             if (@this == null)
@@ -14,6 +16,7 @@ namespace SQLite.Net
             @this.Receive(message);
         }
 
+        [PublicAPI]
         public static void WriteLine(this ITraceListener @this, string format, object arg1)
         {
             if (@this == null)
@@ -24,6 +27,7 @@ namespace SQLite.Net
             @this.Receive(string.Format(CultureInfo.InvariantCulture, format, arg1));
         }
 
+        [PublicAPI]
         public static void WriteLine(this ITraceListener @this, string format, object arg1, object arg2)
         {
             if (@this == null)
@@ -34,6 +38,7 @@ namespace SQLite.Net
             @this.Receive(string.Format(CultureInfo.InvariantCulture, format, arg1, arg2));
         }
 
+        [PublicAPI]
         public static void WriteLine(this ITraceListener @this, string format, params object[] args)
         {
             if (@this == null)

--- a/src/SQLite.Net/packages.config
+++ b/src/SQLite.Net/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="JetBrains.Annotations" version="8.0.5.0" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
+</packages>

--- a/src/SQLite.Net/packages.config
+++ b/src/SQLite.Net/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <packages>
-  <package id="JetBrains.Annotations" version="8.0.5.0" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
+  <package id="JetBrains.Annotations" version="8.0.5.0"
+           targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
 </packages>


### PR DESCRIPTION
Add ReSharper attributes.
By marking public API's with [PublicAPI] it is easier to see the public API surface and R# no longer complains about unused code.
By using [NotNull] and [CanBeNull] R# will give warnings for code that does not/does check for null.