### PR TITLE
Made default and collation attributes work better with attribute subtypes

### DIFF
--- a/src/SQLite.Net/Attributes/DefaultAttribute.cs
+++ b/src/SQLite.Net/Attributes/DefaultAttribute.cs
@@ -15,9 +15,9 @@ namespace SQLite.Net.Attributes
         /// <param name="value">The value to set as default if usePropertyValue is false</param>
         public DefaultAttribute(bool usePropertyValue = true, object value = null)
         {
+            UseProperty = usePropertyValue;
             Value = value;
         }
-
         public bool UseProperty { get; set; }
         public object Value { get; private set; }
     }

--- a/src/SQLite.Net/Orm.cs
+++ b/src/SQLite.Net/Orm.cs
@@ -178,23 +178,19 @@ namespace SQLite.Net
 
         internal static object GetDefaultValue(PropertyInfo p)
         {
-            foreach (var attribute in p.CustomAttributes.Where(a => a.AttributeType == typeof (DefaultAttribute)))
+            foreach (var attribute in p.GetCustomAttributes<DefaultAttribute>())
             {
                 try
                 {
-                    var useProp = (bool) attribute.ConstructorArguments[0].Value;
-
-                    if (!useProp)
-                    {
-                        return Convert.ChangeType(attribute.ConstructorArguments[0].Value, p.PropertyType);
-                    }
+                    if (!attribute.UseProperty)
+                        return Convert.ChangeType(attribute.Value, p.PropertyType);
 
                     var obj = Activator.CreateInstance(p.DeclaringType);
                     return p.GetValue(obj);
                 }
                 catch (Exception exception)
                 {
-                    throw new Exception("Unable to convert " + attribute.ConstructorArguments[0].Value + " to type " + p.PropertyType, exception);
+                    throw new Exception("Unable to convert " + attribute.Value + " to type " + p.PropertyType, exception);
                 }
             }
             return null;

--- a/src/SQLite.Net/Orm.cs
+++ b/src/SQLite.Net/Orm.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) 2012 Krueger Systems, Inc.
 // Copyright (c) 2013 Øystein Krog (oystein.krog@gmail.com)
 // 
@@ -150,9 +150,9 @@ namespace SQLite.Net
 
         internal static string Collation(MemberInfo p)
         {
-            foreach (var attribute in p.CustomAttributes.Where(attribute => attribute.AttributeType == typeof (CollationAttribute)))
+            foreach (var attribute in p.GetCustomAttributes<CollationAttribute>())
             {
-                return (string) attribute.ConstructorArguments[0].Value;
+                return attribute.Value;
             }
             return string.Empty;
         }

--- a/tests/CollateTest.cs
+++ b/tests/CollateTest.cs
@@ -89,5 +89,98 @@ namespace SQLite.Net.Tests
             Assert.AreEqual(0, (from o in db.Table<TestObj>() where o.CollateNoCase == "Alpha" select o).Count());
             Assert.AreEqual(0, (from o in db.Table<TestObj>() where o.CollateNoCase == "ALPHA" select o).Count());
         }
+
+        /// <summary>
+        /// A possible better way of specifying the type of the collation
+        /// </summary>
+        private enum CollationType
+        {
+            BINARY,
+            RTRIM,
+            NOCASE
+        }
+
+        /// <summary>
+        /// A subtype of the collation attribute that allows the use of <see cref="CollationType"/>
+        /// </summary>
+        private class EasierCollationAttribute : CollationAttribute
+        {
+            public EasierCollationAttribute(CollationType type) : base(type.ToString())
+            {
+                
+            }
+        }
+
+        public class TestObjWithSubtypedAttributes
+        {
+            [AutoIncrement, PrimaryKey]
+            public int Id { get; set; }
+
+            public string CollateDefault { get; set; }
+
+            [EasierCollation(CollationType.BINARY)]
+            public string CollateBinary { get; set; }
+
+            [EasierCollation(CollationType.RTRIM)]
+            public string CollateRTrim { get; set; }
+
+            [EasierCollation(CollationType.NOCASE)]
+            public string CollateNoCase { get; set; }
+
+            public override string ToString()
+            {
+                return string.Format("[TestObj: Id={0}]", Id);
+            }
+        }
+
+        public class TestDbSubtype : SQLiteConnection
+        {
+            public TestDbSubtype(ISQLitePlatform sqlitePlatform, String path)
+                : base(sqlitePlatform, path)
+            {
+                TraceListener = DebugTraceListener.Instance;
+                CreateTable<TestObjWithSubtypedAttributes>();
+            }
+        }
+
+        /// <summary>
+        /// The same test as before but with a subtyped collation attribute.
+        /// </summary>
+        [Test]
+        public void CollateAttributeSubtype()
+        {
+            var obj = new TestObjWithSubtypedAttributes
+            {
+                CollateDefault = "Alpha ",
+                CollateBinary = "Alpha ",
+                CollateRTrim = "Alpha ",
+                CollateNoCase = "Alpha ",
+            };
+
+            var db = new TestDbSubtype(new SQLitePlatformTest(), TestPath.GetTempFileName());
+
+            db.Insert(obj);
+
+            var testTable = db.Table<TestObjWithSubtypedAttributes>();
+            Assert.AreEqual(1, (from o in testTable where o.CollateDefault == "Alpha " select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateDefault == "ALPHA " select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateDefault == "Alpha" select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateDefault == "ALPHA" select o).Count());
+
+            Assert.AreEqual(1, (from o in testTable where o.CollateBinary == "Alpha " select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateBinary == "ALPHA " select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateBinary == "Alpha" select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateBinary == "ALPHA" select o).Count());
+
+            Assert.AreEqual(1, (from o in testTable where o.CollateRTrim == "Alpha " select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateRTrim == "ALPHA " select o).Count());
+            Assert.AreEqual(1, (from o in testTable where o.CollateRTrim == "Alpha" select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateRTrim == "ALPHA" select o).Count());
+
+            Assert.AreEqual(1, (from o in testTable where o.CollateNoCase == "Alpha " select o).Count());
+            Assert.AreEqual(1, (from o in testTable where o.CollateNoCase == "ALPHA " select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateNoCase == "Alpha" select o).Count());
+            Assert.AreEqual(0, (from o in testTable where o.CollateNoCase == "ALPHA" select o).Count());
+        }
     }
 }

--- a/tests/DefaulAttributeTest.cs
+++ b/tests/DefaulAttributeTest.cs
@@ -28,7 +28,7 @@ namespace SQLite.Net.Tests
         private class WithDefaultValue
         {
 
-            public static int IntVal = 666;
+            public const int IntVal = 666;
             public static decimal DecimalVal = 666.666m;
             public static string StringVal = "Working String";
             public static DateTime DateTimegVal = new DateTime(2014, 2, 13);
@@ -57,6 +57,21 @@ namespace SQLite.Net.Tests
             [Default]
             public string TestString { get; set; }
 
+
+            [Default(value: IntVal, usePropertyValue: false)]
+            public int DefaultValueInAttributeTestInt { get; set; }
+
+            public class Default666Attribute : DefaultAttribute
+            {
+                public Default666Attribute() :base(usePropertyValue:false, value:IntVal)
+                {
+                    
+                }
+            }
+
+            [Default666]
+            public int TestIntWithSubtypeOfDefault { get; set; }
+
         }
 
         [Test]
@@ -73,6 +88,7 @@ namespace SQLite.Net.Tests
                     if (col.PropertyName == "TestInt" && !col.DefaultValue.Equals(WithDefaultValue.IntVal))
                         failed += " , TestInt does not equal " + WithDefaultValue.IntVal;
 
+
                     if (col.PropertyName == "TestDecimal" && !col.DefaultValue.Equals(WithDefaultValue.DecimalVal))
                         failed += "TestDecimal does not equal " + WithDefaultValue.DecimalVal;
 
@@ -81,8 +97,15 @@ namespace SQLite.Net.Tests
 
                     if (col.PropertyName == "TestString" && !col.DefaultValue.Equals(WithDefaultValue.StringVal))
                         failed += "TestString does not equal " + WithDefaultValue.StringVal;
+
+                    if (col.PropertyName == "DefaultValueInAttributeTestInt" && !col.DefaultValue.Equals(WithDefaultValue.IntVal))
+                        failed += " , DefaultValueInAttributeTestInt does not equal " + WithDefaultValue.IntVal;
+
+                    if (col.PropertyName == "TestIntWithSubtypeOfDefault" && !col.DefaultValue.Equals(WithDefaultValue.IntVal))
+                        failed += " , TestIntWithSubtypeOfDefault does not equal " + WithDefaultValue.IntVal;
+
                 }
-                
+
                 Assert.True(string.IsNullOrWhiteSpace(failed), failed);
 
             }


### PR DESCRIPTION
Fixed the code that deals with the DefaultAttribute and the CollationAttribute to allow subtypes of them to be used,

Also added some tests to demonstrate that it works and provide some motivation for why this is a useful feature.