### PR TITLE
Cleanup TableMapping, abstract out ActiveInsertCommand, and facilitate TableMapping sharing between connections

### DIFF
--- a/src/SQLite.Net/ActiveInsertCommand.cs
+++ b/src/SQLite.Net/ActiveInsertCommand.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace SQLite.Net
 {
-    public class ActiveInsertCommand
+    internal class ActiveInsertCommand
     {
         private readonly TableMapping _tableMapping;
         private PreparedSqlLiteInsertCommand _insertCommand;

--- a/src/SQLite.Net/ActiveInsertCommand.cs
+++ b/src/SQLite.Net/ActiveInsertCommand.cs
@@ -67,10 +67,11 @@ namespace SQLite.Net
                     string.Join(",", (from c in cols
                         select "?").ToArray()), extra);
             }
-
-            var insertCommand = new PreparedSqlLiteInsertCommand(conn.Platform, conn);
-            insertCommand.CommandText = insertSql;
-            return insertCommand;
+            
+            return new PreparedSqlLiteInsertCommand(conn)
+            {
+                CommandText = insertSql
+            };
         }
     }
 }

--- a/src/SQLite.Net/ActiveInsertCommand.cs
+++ b/src/SQLite.Net/ActiveInsertCommand.cs
@@ -1,0 +1,76 @@
+// Author: Prasanna V. Loganathar
+// Created: 2:37 PM 07-03-2015
+// Project: SQLite.Net
+// License: See project license
+
+using System;
+using System.Linq;
+
+namespace SQLite.Net
+{
+    public class ActiveInsertCommand
+    {
+        private readonly TableMapping _tableMapping;
+        private PreparedSqlLiteInsertCommand _insertCommand;
+        private string _insertCommandExtra;
+
+        public ActiveInsertCommand(TableMapping tableMapping)
+        {
+            _tableMapping = tableMapping;
+        }
+
+        public PreparedSqlLiteInsertCommand GetCommand(SQLiteConnection conn, string extra)
+        {
+            if (_insertCommand == null)
+            {
+                _insertCommand = CreateCommand(conn, extra);
+                _insertCommandExtra = extra;
+            }
+            else if (_insertCommandExtra != extra)
+            {
+                _insertCommand.Dispose();
+                _insertCommand = CreateCommand(conn, extra);
+                _insertCommandExtra = extra;
+            }
+            return _insertCommand;
+        }
+
+        protected internal void Dispose()
+        {
+            if (_insertCommand != null)
+            {
+                _insertCommand.Dispose();
+                _insertCommand = null;
+            }
+        }
+
+        private PreparedSqlLiteInsertCommand CreateCommand(SQLiteConnection conn, string extra)
+        {
+            var cols = _tableMapping.InsertColumns;
+            string insertSql;
+            if (!cols.Any() && _tableMapping.Columns.Count() == 1 && _tableMapping.Columns[0].IsAutoInc)
+            {
+                insertSql = string.Format("insert {1} into \"{0}\" default values", _tableMapping.TableName, extra);
+            }
+            else
+            {
+                var replacing = string.Compare(extra, "OR REPLACE", StringComparison.OrdinalIgnoreCase) == 0;
+
+                if (replacing)
+                {
+                    cols = _tableMapping.Columns;
+                }
+
+                insertSql = string.Format("insert {3} into \"{0}\"({1}) values ({2})", _tableMapping.TableName,
+                    string.Join(",", (from c in cols
+                        select "\"" + c.Name + "\"").ToArray()),
+                    string.Join(",", (from c in cols
+                        select "?").ToArray()), extra);
+            }
+
+            var insertCommand = new PreparedSqlLiteInsertCommand(conn.Platform, conn);
+            insertCommand.CommandText = insertSql;
+            return insertCommand;
+        }
+    }
+}

--- a/src/SQLite.Net/SQLite.Net.csproj
+++ b/src/SQLite.Net/SQLite.Net.csproj
@@ -62,6 +62,7 @@
     <Compile Include="..\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="ActiveInsertCommand.cs" />
     <Compile Include="Attributes\DefaultAttribute.cs" />
     <Compile Include="Attributes\NotNullAttribute.cs" />
     <Compile Include="BaseTableQuery.cs" />

--- a/src/SQLite.Net/SQLiteConnection.cs
+++ b/src/SQLite.Net/SQLiteConnection.cs
@@ -318,12 +318,8 @@ namespace SQLite.Net
         /// </returns>
         public int CreateTable(Type ty, CreateFlags createFlags = CreateFlags.None)
         {
-            TableMapping map;
-            if (!_tableMappings.TryGetValue(ty.FullName, out map))
-            {
-                map = GetMapping(ty, createFlags);
-                _tableMappings.Add(ty.FullName, map);
-            }
+            var map = GetMapping(ty, createFlags);
+
             var query = "create table if not exists \"" + map.TableName + "\"(\n";
 
             var mapColumns = map.Columns;

--- a/src/SQLite.Net/SQLiteConnection.cs
+++ b/src/SQLite.Net/SQLiteConnection.cs
@@ -51,10 +51,10 @@ namespace SQLite.Net
         private readonly Random _rand = new Random();
         private TimeSpan _busyTimeout;
         private long _elapsedMilliseconds;
-        private Dictionary<string, TableMapping> _mappings;
         private bool _open;
         private IStopwatch _sw;
-        private Dictionary<string, TableMapping> _tables;
+        private readonly IDictionary<string, TableMapping> _tableMappings;
+        private IDictionary<TableMapping, ActiveInsertCommand> _insertCommandCache; 
         private int _transactionDepth;
 
         static SQLiteConnection()
@@ -83,6 +83,11 @@ namespace SQLite.Net
         ///     Blob serializer to use for storing undefined and complex data structures. If left null
         ///     these types will thrown an exception as usual.
         /// </param>
+        /// <param name="tableMappings">
+        ///     Exisiting table mapping that the connection can use. If its null, it creates the mappings,
+        ///     if and when required. The mappings are also created when an unknown type is used for the first
+        ///     time.
+        /// </param>
         /// <param name="extraTypeMappings">
         ///     Any extra type mappings that you wish to use for overriding the default for creating
         ///     column definitions for SQLite DDL in the class Orm (snake in Swedish).
@@ -95,10 +100,11 @@ namespace SQLite.Net
             string databasePath,
             bool storeDateTimeAsTicks = false,
             IBlobSerializer serializer = null,
+            IDictionary<string, TableMapping> tableMappings = null,
             IDictionary<Type, string> extraTypeMappings = null,
             IContractResolver resolver = null)
             : this(sqlitePlatform, databasePath, SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create, storeDateTimeAsTicks,
-                serializer, extraTypeMappings, resolver)
+                serializer, tableMappings, extraTypeMappings, resolver)
         {
         }
 
@@ -120,6 +126,11 @@ namespace SQLite.Net
         ///     Blob serializer to use for storing undefined and complex data structures. If left null
         ///     these types will thrown an exception as usual.
         /// </param>
+        /// <param name="tableMappings">
+        ///     Exisiting table mapping that the connection can use. If its null, it creates the mappings,
+        ///     if and when required. The mappings are also created when an unknown type is used for the first
+        ///     time.
+        /// </param>
         /// <param name="extraTypeMappings">
         ///     Any extra type mappings that you wish to use for overriding the default for creating
         ///     column definitions for SQLite DDL in the class Orm (snake in Swedish).
@@ -128,13 +139,14 @@ namespace SQLite.Net
         ///     A contract resovler for resolving interfaces to concreate types during object creation
         /// </param>
         public SQLiteConnection(ISQLitePlatform sqlitePlatform, string databasePath, SQLiteOpenFlags openFlags,
-            bool storeDateTimeAsTicks = false, IBlobSerializer serializer = null,
-            IDictionary<Type, string> extraTypeMappings = null, IContractResolver resolver = null)
+            bool storeDateTimeAsTicks = false, IBlobSerializer serializer = null, IDictionary<string, TableMapping> tableMappings = null, IDictionary<Type, string> extraTypeMappings = null, IContractResolver resolver = null)
         {
             ExtraTypeMappings = extraTypeMappings ?? new Dictionary<Type, string>();
             Serializer = serializer;
             Platform = sqlitePlatform;
             Resolver = resolver ?? ContractResolver.Current;
+
+            _tableMappings = tableMappings ?? new Dictionary<string, TableMapping>();
 
             if (string.IsNullOrEmpty(databasePath))
             {
@@ -191,7 +203,7 @@ namespace SQLite.Net
         /// </summary>
         public IEnumerable<TableMapping> TableMappings
         {
-            get { return _tables != null ? _tables.Values : Enumerable.Empty<TableMapping>(); }
+            get { return _tableMappings.Values; }
         }
 
         /// <summary>
@@ -243,16 +255,15 @@ namespace SQLite.Net
         /// </returns>
         public TableMapping GetMapping(Type type, CreateFlags createFlags = CreateFlags.None)
         {
-            if (_mappings == null)
-            {
-                _mappings = new Dictionary<string, TableMapping>();
-            }
             TableMapping map;
-            if (!_mappings.TryGetValue(type.FullName, out map))
-            {
-                map = new TableMapping(Platform, type, createFlags);
-                _mappings[type.FullName] = map;
-            }
+            return _tableMappings.TryGetValue(type.FullName, out map) ? map : CreateAndSetMapping(type, createFlags, _tableMappings);
+        }
+
+        private TableMapping CreateAndSetMapping(Type type, CreateFlags createFlags, IDictionary<string, TableMapping> mapTable)
+        {
+            var props = Platform.ReflectionService.GetPublicInstanceProperties(type);
+            var map = new TableMapping(type, props, createFlags);
+            mapTable[type.FullName] = map;
             return map;
         }
 
@@ -307,15 +318,11 @@ namespace SQLite.Net
         /// </returns>
         public int CreateTable(Type ty, CreateFlags createFlags = CreateFlags.None)
         {
-            if (_tables == null)
-            {
-                _tables = new Dictionary<string, TableMapping>();
-            }
             TableMapping map;
-            if (!_tables.TryGetValue(ty.FullName, out map))
+            if (!_tableMappings.TryGetValue(ty.FullName, out map))
             {
                 map = GetMapping(ty, createFlags);
-                _tables.Add(ty.FullName, map);
+                _tableMappings.Add(ty.FullName, map);
             }
             var query = "create table if not exists \"" + map.TableName + "\"(\n";
 
@@ -1293,7 +1300,6 @@ namespace SQLite.Net
                 return 0;
             }
 
-
             var map = GetMapping(objType);
 
             if (map.PK != null && map.PK.IsAutoGuid)
@@ -1310,14 +1316,14 @@ namespace SQLite.Net
 
             var replacing = string.Compare(extra, "OR REPLACE", StringComparison.OrdinalIgnoreCase) == 0;
 
-            var cols = replacing ? map.InsertOrReplaceColumns : map.InsertColumns;
+            var cols = replacing ? map.Columns : map.InsertColumns;
             var vals = new object[cols.Length];
             for (var i = 0; i < vals.Length; i++)
             {
                 vals[i] = cols[i].GetValue(obj);
             }
 
-            var insertCmd = map.GetInsertCommand(this, extra);
+            var insertCmd = GetInsertCommand(map, extra);
             int count;
             try
             {
@@ -1339,6 +1345,24 @@ namespace SQLite.Net
             }
 
             return count;
+        }
+
+
+        private PreparedSqlLiteInsertCommand GetInsertCommand(TableMapping map, string extra)
+        {
+            ActiveInsertCommand cmd;
+            if (_insertCommandCache == null)
+            {
+                _insertCommandCache = new Dictionary<TableMapping, ActiveInsertCommand>();
+            }
+
+            if (!_insertCommandCache.TryGetValue(map, out cmd))
+            {
+                cmd = new ActiveInsertCommand(map);
+                _insertCommandCache[map] = cmd;
+            }
+
+            return cmd.GetCommand(this, extra);
         }
 
         /// <summary>
@@ -1520,9 +1544,9 @@ namespace SQLite.Net
             {
                 try
                 {
-                    if (_mappings != null)
+                    if (_insertCommandCache != null)
                     {
-                        foreach (var sqlInsertCommand in _mappings.Values)
+                        foreach (var sqlInsertCommand in _insertCommandCache.Values)
                         {
                             sqlInsertCommand.Dispose();
                         }

--- a/src/SQLite.Net/SQLiteConnectionWithLock.cs
+++ b/src/SQLite.Net/SQLiteConnectionWithLock.cs
@@ -31,11 +31,7 @@ namespace SQLite.Net
         private readonly object _lockPoint = new object();
 
         public SQLiteConnectionWithLock(ISQLitePlatform sqlitePlatform, SQLiteConnectionString connectionString)
-            : base(
-                sqlitePlatform, connectionString.DatabasePath, connectionString.StoreDateTimeAsTicks, connectionString.Serializer, null,
-                connectionString.Resolver)
-        {
-        }
+            : base(sqlitePlatform, connectionString.DatabasePath, connectionString.StoreDateTimeAsTicks, connectionString.Serializer, null, null, connectionString.Resolver) { }
 
         public IDisposable Lock()
         {


### PR DESCRIPTION
- Removed everything from TableMapping that makes its specific to SQLiteConnection
- Remove all unnecessary dependencies of TableMapping
- Create ActiveInsertCommand class that has everything in the Map that's specific to SQLiteConnection
- TableMapping is now lighter, reusable, and can now be shared between SQLiteConnections, increasing the performance multifold, if new connections are created often. 
- This also now facilitates a real ConnectionPool without reflecting all over again on types which similar connections have already mapped out.