### PR TITLE
Removed the select method from Table query

### DIFF
--- a/src/SQLite.Net/TableQuery.cs
+++ b/src/SQLite.Net/TableQuery.cs
@@ -44,7 +44,6 @@ namespace SQLite.Net
         private int? _limit;
         private int? _offset;
         private List<Ordering> _orderBys;
-        private Expression _selector;
         private Expression _where;
 
         private TableQuery(ISQLitePlatform platformImplementation, SQLiteConnection conn, TableMapping table)
@@ -99,7 +98,6 @@ namespace SQLite.Net
                 _joinOuter = _joinOuter,
                 _joinOuterKeySelector = _joinOuterKeySelector,
                 _joinSelector = _joinSelector,
-                _selector = _selector,
                 _orderBys = _orderBys == null ? null : new List<Ordering>(_orderBys)
             };
         }
@@ -280,18 +278,6 @@ namespace SQLite.Net
                 _joinInnerKeySelector = innerKeySelector,
                 _joinSelector = resultSelector
             };
-            return q;
-        }
-
-        [PublicAPI]
-        public TableQuery<TResult> Select<TResult>([NotNull] Expression<Func<T, TResult>> selector)
-        {
-            if (selector == null)
-            {
-                throw new ArgumentNullException("selector");
-            }
-            var q = Clone<TResult>();
-            q._selector = selector;
             return q;
         }
 

--- a/tests/SelectTests.cs
+++ b/tests/SelectTests.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SQLite.Net.Async;
+using SQLite.Net.Attributes;
+
+#if __WIN32__
+using SQLitePlatformTest = SQLite.Net.Platform.Win32.SQLitePlatformWin32;
+#elif WINDOWS_PHONE
+using SQLitePlatformTest = SQLite.Net.Platform.WindowsPhone8.SQLitePlatformWP8;
+#elif __WINRT__
+using SQLitePlatformTest = SQLite.Net.Platform.WinRT.SQLitePlatformWinRT;
+#elif __IOS__
+using SQLitePlatformTest = SQLite.Net.Platform.XamarinIOS.SQLitePlatformIOS;
+#elif __ANDROID__
+using SQLitePlatformTest = SQLite.Net.Platform.XamarinAndroid.SQLitePlatformAndroid;
+#else
+using SQLitePlatformTest = SQLite.Net.Platform.Generic.SQLitePlatformGeneric;
+#endif
+
+namespace SQLite.Net.Tests
+{
+
+
+    /// <summary>
+    ///     Defines tests that exercise async behaviour.
+    /// </summary>
+    [TestFixture]
+    public class SelectTest
+    {
+        public class TestObj
+        {
+            [AutoIncrement, PrimaryKey]
+            public int Id { get; set; }
+
+            public int Order { get; set; }
+
+            public override string ToString()
+            {
+                return string.Format("[TestObj: Id={0}, Order={1}]", Id, Order);
+            }
+        }
+
+        public class TestDb : SQLiteConnection
+        {
+            public TestDb(String path)
+                : base(new SQLitePlatformTest(), path)
+            {
+                CreateTable<TestObj>();
+            }
+        }
+
+        [Test]
+        public void SelectWorks()
+        {
+            using (var db = new TestDb(TestPath.GetTempFileName()))
+            {
+                db.Insert(new TestObj() {Order = 5});
+                try
+                {
+                    Assert.That(db.Table<TestObj>().Select(obj => obj.Order * 2).First(), Is.EqualTo(10));
+                }
+                catch (NotImplementedException)
+                {
+                    //Allow Not implemented exceptions as the selection may be too complex.
+                }
+            }
+           
+        }
+    }
+}


### PR DESCRIPTION
The select method on table query was completely broken so it would be
safer to just get rid of it (probably meaning the user falls back to
IEnumerable<>.Select) than let it continue