### PR TITLE
Change to IntPtr.Size

### DIFF
--- a/src/SQLite.Net.Platform.Win32/SQliteApiWin32Internal.cs
+++ b/src/SQLite.Net.Platform.Win32/SQliteApiWin32Internal.cs
@@ -11,7 +11,7 @@ namespace SQLite.Net.Platform.Win32
         static SQLiteApiWin32Internal()
         {
             // load native library
-            int ptrSize = Marshal.SizeOf(typeof (IntPtr));
+            int ptrSize = IntPtr.Size;
             string relativePath = ptrSize == 8 ? @"x64\SQLite.Interop.dll" : @"x86\SQLite.Interop.dll";
             string assemblyCurrentPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             string assemblyInteropPath = Path.Combine(assemblyCurrentPath, relativePath);


### PR DESCRIPTION
This should be used over marshaling, because it is more direct and less prone to errors.  In our releases we have seen problems using the marshaling method to determine bitness level.

```
System.TypeInitializationException: The type initializer for 'SQLite.Net.Platform.Win32.SQLiteApiWin32Internal' threw an exception. ---> System.Exception: Failed to load native sqlite library
   at SQLite.Net.Platform.Win32.SQLiteApiWin32Internal..cctor()
   --- End of inner exception stack trace ---
   at SQLite.Net.Platform.Win32.SQLiteApiWin32Internal.sqlite3_open_v2(Byte[] filename, IntPtr& db, Int32 flags, IntPtr zvfs)
   at SQLite.Net.Platform.Win32.SQLiteApiWin32.Open(Byte[] filename, IDbHandle& db, Int32 flags, IntPtr zvfs)
   at SQLite.Net.SQLiteConnection..ctor(ISQLitePlatform sqlitePlatform, String databasePath, SQLiteOpenFlags openFlags, Boolean storeDateTimeAsTicks, IBlobSerializer serializer, IDictionary`2 extraTypeMappings)
   at SQLite.Net.SQLiteConnection..ctor(ISQLitePlatform sqlitePlatform, String databasePath, Boolean storeDateTimeAsTicks, IBlobSerializer serializer, IDictionary`2 extraTypeMappings)
   at AmazonCloudDrive.ViewModels.Transfer.TransferViewModel.TransferItemErrors..ctor() in c:\BuildAgent\work\ef71310fc0a844aa\CloudDriveClientCore\ViewModels\Transfer\TransferViewModel.cs:line 652
   at AmazonCloudDrive.ViewModels.Transfer.TransferViewModel..ctor(TransferQueueModel queue, CDSStorageService storageService, IObservable`1 halt, NetworkDetector detector, AccountViewModel acctViewModel, IPowerModeChangeEventSource powerModeChangeSource) in c:\BuildAgent\work\ef71310fc0a844aa\CloudDriveClientCore\ViewModels\Transfer\TransferViewModel.cs:line 107
   at AmazonCloudDrive.ViewModels.Transfer.DownloadViewModel..ctor(DownloadQueueModel queue, CDSStorageService storageService, IObservable`1 halt, NetworkDetector detector, IPowerModeChangeEventSource powerModeChangeSource, AccountViewModel acctViewModel) in c:\BuildAgent\work\ef71310fc0a844aa\CloudDriveClientCore\ViewModels\Transfer\DownloadViewModel.cs:line 31
   at AmazonCloudDrive.CloudDriveApplication.Start(AppLaunchMethod method) in c:\BuildAgent\work\ef71310fc0a844aa\SimpleDownloader\CloudDriveApplication.cs:line 244
   at AmazonCloudDrive.CloudDriveProcess.<>c__DisplayClassa.<RunApplication>b__8() in c:\BuildAgent\work\ef71310fc0a844aa\SimpleDownloader\CloudDriveProcess.cs:line 451
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at MS.Internal.Threading.ExceptionFilterHelper.TryCatchWhen(Object source, Delegate method, Object args, Int32 numArgs, Delegate catchHandler)
```