### PR TITLE
Set temp directory on winRT platform.

### DIFF
--- a/src/SQLite.Net.Platform.WinRT/SQLiteApiWinRT.cs
+++ b/src/SQLite.Net.Platform.WinRT/SQLiteApiWinRT.cs
@@ -11,7 +11,7 @@ namespace SQLite.Net.Platform.WinRT
     {
         public SQLiteApiWinRT()
         {
-            SQLite3.SetDirectory( /*temp directory type*/2, Windows.Storage.ApplicationData.Current.TemporaryFolder.Path);
+            SQLite3.SetDirectory(/*temp directory type*/2, Windows.Storage.ApplicationData.Current.TemporaryFolder.Path);
         }
 
         public int BindBlob(IDbStatement stmt, int index, byte[] val, int n, IntPtr free)

--- a/src/SQLite.Net.Platform.WinRT/SQLiteApiWinRT.cs
+++ b/src/SQLite.Net.Platform.WinRT/SQLiteApiWinRT.cs
@@ -9,6 +9,11 @@ namespace SQLite.Net.Platform.WinRT
 {
     public class SQLiteApiWinRT : ISQLiteApiExt
     {
+        public SQLiteApiWinRT()
+        {
+            SQLite3.SetDirectory( /*temp directory type*/2, Windows.Storage.ApplicationData.Current.TemporaryFolder.Path);
+        }
+
         public int BindBlob(IDbStatement stmt, int index, byte[] val, int n, IntPtr free)
         {
             var dbStatement = (DbStatement)stmt;


### PR DESCRIPTION
InsertOrReplace() inside transaction sometimes fails with "SQL logic or missing database"

This is because on winRT we must set temp_directory - https://www.sqlite.org/c3ref/temp_directory.html
Original sqlite-net library do that: https://github.com/praeclarum/sqlite-net/blob/master/src/SQLite.cs#L207

Related to https://github.com/oysteinkrog/SQLite.Net-PCL/issues/144

May be we should do that on WP8, but I don't have WP8 device for testing.