### PR TITLE
Support for composite primary keys

### DIFF
--- a/src/SQLite.Net.Async/SQLiteAsyncConnection.cs
+++ b/src/SQLite.Net.Async/SQLiteAsyncConnection.cs
@@ -234,18 +234,18 @@ namespace SQLite.Net.Async
         }
 
         [PublicAPI]
-        public Task<int> DeleteAsync<T>([NotNull] object pk, CancellationToken cancellationToken = default (CancellationToken))
+        public Task<int> DeleteAsync<T>([NotNull] Dictionary<string,object> pks, CancellationToken cancellationToken = default (CancellationToken))
         {
-            if (pk == null)
+            if (pks == null)
             {
-                throw new ArgumentNullException("pk");
+                throw new ArgumentNullException("pks");
             }
             return Task.Factory.StartNew(() =>
             {
                 var conn = GetConnection();
                 using (conn.Lock())
                 {
-                    return conn.Delete<T>(pk);
+                    return conn.Delete<T>(pks);
                 }
             }, cancellationToken, _taskCreationOptions, _taskScheduler ?? TaskScheduler.Default);
         }

--- a/src/SQLite.Net/Orm.cs
+++ b/src/SQLite.Net/Orm.cs
@@ -37,11 +37,11 @@ namespace SQLite.Net
         public const string ImplicitIndexSuffix = "Id";
 
         internal static string SqlDecl(TableMapping.Column p, bool storeDateTimeAsTicks, IBlobSerializer serializer,
-            IDictionary<Type, string> extraTypeMappings)
+            IDictionary<Type, string> extraTypeMappings, int primaryKeyCount = 0)
         {
             var decl = "\"" + p.Name + "\" " + SqlType(p, storeDateTimeAsTicks, serializer, extraTypeMappings) + " ";
 
-            if (p.IsPK)
+            if (p.IsPK && primaryKeyCount == 1)
             {
                 decl += "primary key ";
             }

--- a/src/SQLite.Net/TableMapping.cs
+++ b/src/SQLite.Net/TableMapping.cs
@@ -57,23 +57,21 @@ namespace SQLite.Net
                 }
             }
             Columns = cols.ToArray();
+            PKs = Columns.Where(col => col.IsPK).ToArray();
             foreach (var c in Columns)
             {
                 if (c.IsAutoInc && c.IsPK)
                 {
                     _autoPk = c;
                 }
-                if (c.IsPK)
-                {
-                    PK = c;
-                }
             }
 
             HasAutoIncPK = _autoPk != null;
 
-            if (PK != null)
+            if (PKs.Length > 0)
             {
-                GetByPrimaryKeySql = string.Format("select * from \"{0}\" where \"{1}\" = ?", TableName, PK.Name);
+                string pksString = string.Join(",", PKs.Select(pk => pk.Name));
+                GetByPrimaryKeySql = string.Format("select * from \"{0}\" where \"{1}\" = ?", TableName, pksString);
             }
             else
             {
@@ -92,7 +90,7 @@ namespace SQLite.Net
         public Column[] Columns { get; private set; }
 
         [PublicAPI]
-        public Column PK { get; private set; }
+        public Column[] PKs { get; private set; }
 
         [PublicAPI]
         public string GetByPrimaryKeySql { get; private set; }

--- a/tests/CreateTableImplicitTest.cs
+++ b/tests/CreateTableImplicitTest.cs
@@ -51,10 +51,11 @@ namespace SQLite.Net.Tests
 
             TableMapping mapping = db.GetMapping<PkAttribute>();
 
-            Assert.IsNotNull(mapping.PK);
-            Assert.AreEqual("Id", mapping.PK.Name);
-            Assert.IsTrue(mapping.PK.IsPK);
-            Assert.IsTrue(mapping.PK.IsAutoInc);
+            Assert.IsNotNull(mapping.PKs);
+            Assert.IsNotEmpty(mapping.PKs);
+            Assert.AreEqual("Id", mapping.PKs[0].Name);
+            Assert.IsTrue(mapping.PKs[0].IsPK);
+            Assert.IsTrue(mapping.PKs[0].IsAutoInc);
         }
 
         [Test]
@@ -66,10 +67,11 @@ namespace SQLite.Net.Tests
 
             TableMapping mapping = db.GetMapping<PkAttribute>();
 
-            Assert.IsNotNull(mapping.PK);
-            Assert.AreEqual("Id", mapping.PK.Name);
-            Assert.IsTrue(mapping.PK.IsPK);
-            Assert.IsTrue(mapping.PK.IsAutoInc);
+            Assert.IsNotNull(mapping.PKs);
+            Assert.IsNotEmpty(mapping.PKs);
+            Assert.AreEqual("Id", mapping.PKs[0].Name);
+            Assert.IsTrue(mapping.PKs[0].IsPK);
+            Assert.IsTrue(mapping.PKs[0].IsAutoInc);
         }
 
         [Test]
@@ -94,10 +96,11 @@ namespace SQLite.Net.Tests
 
             TableMapping mapping = db.GetMapping<NoAttributes>();
 
-            Assert.IsNotNull(mapping.PK);
-            Assert.AreEqual("Id", mapping.PK.Name);
-            Assert.IsTrue(mapping.PK.IsPK);
-            Assert.IsFalse(mapping.PK.IsAutoInc);
+            Assert.IsNotNull(mapping.PKs);
+            Assert.IsNotEmpty(mapping.PKs);
+            Assert.AreEqual("Id", mapping.PKs[0].Name);
+            Assert.IsTrue(mapping.PKs[0].IsPK);
+            Assert.IsFalse(mapping.PKs[0].IsAutoInc);
 
             CheckPK(db);
         }
@@ -111,10 +114,11 @@ namespace SQLite.Net.Tests
 
             TableMapping mapping = db.GetMapping<NoAttributes>();
 
-            Assert.IsNotNull(mapping.PK);
-            Assert.AreEqual("Id", mapping.PK.Name);
-            Assert.IsTrue(mapping.PK.IsPK);
-            Assert.IsTrue(mapping.PK.IsAutoInc);
+            Assert.IsNotNull(mapping.PKs);
+            Assert.IsNotEmpty(mapping.PKs);
+            Assert.AreEqual("Id", mapping.PKs[0].Name);
+            Assert.IsTrue(mapping.PKs[0].IsPK);
+            Assert.IsTrue(mapping.PKs[0].IsAutoInc);
         }
 
         [Test]
@@ -126,10 +130,11 @@ namespace SQLite.Net.Tests
 
             TableMapping mapping = db.GetMapping<NoAttributes>();
 
-            Assert.IsNotNull(mapping.PK);
-            Assert.AreEqual("Id", mapping.PK.Name);
-            Assert.IsTrue(mapping.PK.IsPK);
-            Assert.IsTrue(mapping.PK.IsAutoInc);
+            Assert.IsNotNull(mapping.PKs);
+            Assert.IsNotEmpty(mapping.PKs);
+            Assert.AreEqual("Id", mapping.PKs[0].Name);
+            Assert.IsTrue(mapping.PKs[0].IsPK);
+            Assert.IsTrue(mapping.PKs[0].IsAutoInc);
         }
 
         [Test]
@@ -141,10 +146,11 @@ namespace SQLite.Net.Tests
 
             TableMapping mapping = db.GetMapping<NoAttributes>();
 
-            Assert.IsNotNull(mapping.PK);
-            Assert.AreEqual("Id", mapping.PK.Name);
-            Assert.IsTrue(mapping.PK.IsPK);
-            Assert.IsFalse(mapping.PK.IsAutoInc);
+            Assert.IsNotNull(mapping.PKs);
+            Assert.IsNotEmpty(mapping.PKs);
+            Assert.AreEqual("Id", mapping.PKs[0].Name);
+            Assert.IsTrue(mapping.PKs[0].IsPK);
+            Assert.IsFalse(mapping.PKs[0].IsAutoInc);
         }
 
         [Test]
@@ -156,7 +162,7 @@ namespace SQLite.Net.Tests
 
             TableMapping mapping = db.GetMapping<NoAttributes>();
 
-            Assert.IsNull(mapping.PK);
+            Assert.IsEmpty(mapping.PKs);
 
             TableMapping.Column column = mapping.Columns[2];
             Assert.AreEqual("IndexedId", column.Name);

--- a/tests/InheritanceTest.cs
+++ b/tests/InheritanceTest.cs
@@ -28,7 +28,7 @@ namespace SQLite.Net.Tests
             TableMapping mapping = db.GetMapping<Derived>();
 
             Assert.AreEqual(3, mapping.Columns.Length);
-            Assert.AreEqual("Id", mapping.PK.Name);
+            Assert.AreEqual("Id", mapping.PKs[0].Name);
         }
     }
 }


### PR DESCRIPTION
Code changes to enable composite primary keys.

It was mentioned here. https://github.com/oysteinkrog/SQLite.Net-PCL/issues/72

I think it would be really good to have this supported. I was only able to run tests under Generic, Win32 and WindowsPhone8, others wouldn't build for some reason, I'll have to investigate.

Let me know what you think!