### PR TITLE
Found and fixed a bug in the delete method on TableQuery

### DIFF
--- a/src/SQLite.Net/TableQuery.cs
+++ b/src/SQLite.Net/TableQuery.cs
@@ -144,6 +144,8 @@ namespace SQLite.Net
             }
             if (_limit != null)
             {
+                //SQLite provides a limit to deletions so this would be possible to implement in the future
+                //You would need to take care that the correct order was being applied.
                 throw new NotSupportedException("Cannot delete if a limit has been specified");
             }
             if (_offset != null)

--- a/src/SQLite.Net/TableQuery.cs
+++ b/src/SQLite.Net/TableQuery.cs
@@ -142,8 +142,20 @@ namespace SQLite.Net
             {
                 throw new NotSupportedException("Must be a predicate");
             }
+            if (_limit != null)
+            {
+                throw new NotSupportedException("Cannot delete if a limit has been specified");
+            }
+            if (_offset != null)
+            {
+                throw new NotSupportedException("Cannot delete if an offset has been specified");
+            }
             var lambda = (LambdaExpression) predExpr;
             var pred = lambda.Body;
+            if (_where != null)
+            {
+                pred = Expression.AndAlso(pred, _where);
+            }
             var args = new List<object>();
             var w = CompileExpr(pred, args);
             var cmdText = "delete from \"" + Table.TableName + "\"";

--- a/tests/DeleteTest.cs
+++ b/tests/DeleteTest.cs
@@ -74,6 +74,30 @@ namespace SQLite.Net.Tests
         }
 
         [Test]
+        public void DeleteWithWhereAndPredicate()
+        {
+            var db = CreateDb();
+            var testString = "TestData";
+            var first = db.Insert(new TestTable
+            {
+                Datum = 3,
+                Test = testString
+
+            });
+            var second = db.Insert(new TestTable
+            {
+                Datum = 4,
+                Test = testString
+            });
+
+            //Should only delete first
+            var r = db.Table<TestTable>().Where(t => t.Datum == 3).Delete(t => t.Test == testString);
+
+            Assert.AreEqual(1, r);
+            Assert.AreEqual(Count + 1, db.Table<TestTable>().Count());
+        }
+
+        [Test]
         public void DeleteEntityOne()
         {
             var db = CreateDb();


### PR DESCRIPTION
If the user called db.Table<TableType>().Where(predicate1).Delete(predicate2) then completely unintuitively, the first predicate is silently ignored.

I fixed the issue to make it do the right thing and added some similar checks that other parts of the query hadn't already been set. e.g. if Take or skip had been called.