### PR TITLE
Allow to derive from SQLiteConnection and to create derived SQLiteComman...

### DIFF
--- a/src/SQLite.Net/SQLiteCommand.cs
+++ b/src/SQLite.Net/SQLiteCommand.cs
@@ -36,10 +36,10 @@ namespace SQLite.Net
 
         [NotNull] private readonly List<Binding> _bindings;
 
-        private readonly SQLiteConnection _conn;
-        private readonly ISQLitePlatform _sqlitePlatform;
+        protected readonly SQLiteConnection _conn;
+        protected readonly ISQLitePlatform _sqlitePlatform;
 
-        internal SQLiteCommand(ISQLitePlatform platformImplementation, SQLiteConnection conn)
+        internal protected SQLiteCommand(ISQLitePlatform platformImplementation, SQLiteConnection conn)
         {
             _sqlitePlatform = platformImplementation;
             _conn = conn;


### PR DESCRIPTION
...d instances within SQLiteConnection.NewCommand.

SQLiteConnection.NewCommand was public virtual but the constructure of SQLiteCommand was internal.....

We need this implement own SQLiteConnection and to overide NewCommand as already idented. 

For example, with some other locking code which is not shown here we use this for a Abort request mechanism:

public class SQLiteDataConnection : SQLiteConnection
	{
		public SQLiteDataConnection(ISQLitePlatform sqlitePlatform, string databasePath)
			:base(sqlitePlatform, databasePath)
		{
		}

		private class SQLiteDataCommand: SQLiteCommand
		{
			internal SQLiteDataCommand(ISQLitePlatform platformImplementation, SQLiteConnection conn)
				: base(platformImplementation, conn)
			{
			}

			protected override void OnInstanceCreated(object obj)
			{
				((SQLiteDataConnection)this._conn).TryAbort();

				base.OnInstanceCreated(obj);
			}
		}

		protected override SQLiteCommand NewCommand()
		{
			return new SQLiteDataCommand(Platform, this);
		}

		private void TryAbort()
		{
			if (this.abortRequest)
				throw new System.OperationCanceledException();
		}

		private volatile bool abortRequest;

		internal void SetAbortRequest()
		{
			this.abortRequest = true;
		}

		internal void ResetAbortRequest()
		{
			this.abortRequest = false;
		}
	}