### PR TITLE
Adds (optional) ctor parameters from SQLiteConnection to SQLiteConnectionWithLock

### DIFF
--- a/src/SQLite.Net/SQLiteConnectionWithLock.cs
+++ b/src/SQLite.Net/SQLiteConnectionWithLock.cs
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using JetBrains.Annotations;
 using SQLite.Net.Interop;
@@ -32,8 +33,11 @@ namespace SQLite.Net
         private readonly object _lockPoint = new object();
 
         [PublicAPI]
-        public SQLiteConnectionWithLock([NotNull] ISQLitePlatform sqlitePlatform, [NotNull] SQLiteConnectionString connectionString)
-            : base(sqlitePlatform, connectionString.DatabasePath, connectionString.StoreDateTimeAsTicks, connectionString.Serializer, null, null, connectionString.Resolver) { }
+        public SQLiteConnectionWithLock([NotNull] ISQLitePlatform sqlitePlatform, 
+                                        [NotNull] SQLiteConnectionString connectionString, 
+                                        IDictionary<string, TableMapping> tableMappings = null, 
+                                        IDictionary<Type, string> extraTypeMappings = null)
+            : base(sqlitePlatform, connectionString.DatabasePath, connectionString.StoreDateTimeAsTicks, connectionString.Serializer, tableMappings, extraTypeMappings, connectionString.Resolver) { }
 
         [PublicAPI]
         public IDisposable Lock()


### PR DESCRIPTION
SQLiteConnectionWithLock was missing a way to setup tableMappings and extraTypeMappings while the base class SQLiteConnection  was accepting these values as constructor parameters.

For some special use cases we are planning to provide custom tableMappings. This works fine on SQLiteConnection but there was no way to use the same stuff on SQLiteConnectionWithLock. That was most surprising since SQLiteConnectionWithLock inherits from SQLiteConnection.