### PR TITLE
SourceID() is now marshalling API with PtrToStringAnsi(). 

### DIFF
--- a/src/SQLite.Net.Platform.Generic/SQLiteApiGeneric.cs
+++ b/src/SQLite.Net.Platform.Generic/SQLiteApiGeneric.cs
@@ -27,7 +27,7 @@ namespace SQLite.Net.Platform.Generic
 
         public string SourceID()
         {            
-			return Marshal.PtrToStringAuto(SQLiteApiGenericInternal.sqlite3_sourceid());
+			return Marshal.PtrToStringAnsi(SQLiteApiGenericInternal.sqlite3_sourceid());
         }        
 
         public Result EnableLoadExtension(IDbHandle db, int onoff)

--- a/src/SQLite.Net.Platform.Win32/SQLiteApiWin32.cs
+++ b/src/SQLite.Net.Platform.Win32/SQLiteApiWin32.cs
@@ -27,7 +27,7 @@ namespace SQLite.Net.Platform.Win32
         
         public string SourceID()
         {
-			return Marshal.PtrToStringAuto(SQLiteApiWin32Internal.sqlite3_sourceid());            
+			return Marshal.PtrToStringAnsi(SQLiteApiWin32Internal.sqlite3_sourceid());            
         }                
 
         public Result EnableLoadExtension(IDbHandle db, int onoff)

--- a/src/SQLite.Net.Platform.WinRT/SQLiteApiWinRT.cs
+++ b/src/SQLite.Net.Platform.WinRT/SQLiteApiWinRT.cs
@@ -159,7 +159,7 @@ namespace SQLite.Net.Platform.WinRT
 
         public string SourceID()
         {
-            return Marshal.PtrToStringAuto(SQLite3.sqlite3_sourceid());  
+            return Marshal.PtrToStringAnsi(SQLite3.sqlite3_sourceid());  
         }        
 
         public Result EnableLoadExtension(IDbHandle db, int onoff)

--- a/src/SQLite.Net.Platform.XamarinAndroid/SQLiteApiAndroid.cs
+++ b/src/SQLite.Net.Platform.XamarinAndroid/SQLiteApiAndroid.cs
@@ -27,7 +27,7 @@ namespace SQLite.Net.Platform.XamarinAndroid
 
         public string SourceID()
         {
-			return Marshal.PtrToStringAuto(SQLiteApiAndroidInternal.sqlite3_sourceid());            
+			return Marshal.PtrToStringAnsi(SQLiteApiAndroidInternal.sqlite3_sourceid());            
         }                
 
         public Result EnableLoadExtension(IDbHandle db, int onoff)

--- a/src/SQLite.Net.Platform.XamarinIOS.Unified/SQLiteApiIOS.cs
+++ b/src/SQLite.Net.Platform.XamarinIOS.Unified/SQLiteApiIOS.cs
@@ -27,7 +27,7 @@ namespace SQLite.Net.Platform.XamarinIOS
         
         public string SourceID()
         {
-            return Marshal.PtrToStringAuto(SQLiteApiIOSInternal.sqlite3_sourceid());
+            return Marshal.PtrToStringAnsi(SQLiteApiIOSInternal.sqlite3_sourceid());
         }                     
 
         public Result EnableLoadExtension(IDbHandle db, int onoff)

--- a/src/SQLite.Net.Platform.XamarinIOS/SQLiteApiIOS.cs
+++ b/src/SQLite.Net.Platform.XamarinIOS/SQLiteApiIOS.cs
@@ -22,7 +22,7 @@ namespace SQLite.Net.Platform.XamarinIOS {
 
         public string SourceID()
         {
-            return Marshal.PtrToStringAuto(SQLiteApiIOSInternal.sqlite3_sourceid());
+            return Marshal.PtrToStringAnsi(SQLiteApiIOSInternal.sqlite3_sourceid());
         }                	
 
 		public Result EnableLoadExtension(IDbHandle db, int onoff) {


### PR DESCRIPTION
The underlying API will always return char*, PtrStringToAuto was causing the system to treat the char* as unicode.