### PR TITLE
Adds optional parameter nativeInteropSearchPath to SQLiteApiWin32() t…

### DIFF
--- a/src/SQLite.Net.Platform.Win32/SQLite.Net.Platform.Win32.csproj
+++ b/src/SQLite.Net.Platform.Win32/SQLite.Net.Platform.Win32.csproj
@@ -52,6 +52,7 @@
     <Compile Include="ReflectionServiceWin32.cs" />
     <Compile Include="SQLiteApiWin32.cs" />
     <Compile Include="SQLiteApiWin32Internal.cs" />
+    <Compile Include="SQLiteApiWin32InternalConfiguration.cs" />
     <Compile Include="SQLitePlatformWin32.cs" />
     <Compile Include="StopwatchFactoryWin32.cs" />
     <Compile Include="VolatileServiceWin32.cs" />

--- a/src/SQLite.Net.Platform.Win32/SQLiteApiWin32.cs
+++ b/src/SQLite.Net.Platform.Win32/SQLiteApiWin32.cs
@@ -6,6 +6,12 @@ namespace SQLite.Net.Platform.Win32
 {
     public class SQLiteApiWin32 : ISQLiteApiExt
     {
+        public SQLiteApiWin32(string nativeInteropSearchPath = null)
+        {
+            if (nativeInteropSearchPath  != null)
+                SQLiteApiWin32InternalConfiguration.NativeInteropSearchPath = nativeInteropSearchPath;
+        }
+
         public Result Open(byte[] filename, out IDbHandle db, int flags, IntPtr zvfs)
         {
             IntPtr dbPtr;

--- a/src/SQLite.Net.Platform.Win32/SQLiteApiWin32InternalConfiguration.cs
+++ b/src/SQLite.Net.Platform.Win32/SQLiteApiWin32InternalConfiguration.cs
@@ -1,0 +1,7 @@
+namespace SQLite.Net.Platform.Win32
+{
+    internal static class SQLiteApiWin32InternalConfiguration
+    {
+        public static string NativeInteropSearchPath { get; set; }
+    }
+}

--- a/src/SQLite.Net.Platform.Win32/SQLitePlatformWin32.cs
+++ b/src/SQLite.Net.Platform.Win32/SQLitePlatformWin32.cs
@@ -4,9 +4,9 @@ namespace SQLite.Net.Platform.Win32
 {
     public class SQLitePlatformWin32 : ISQLitePlatform
     {
-        public SQLitePlatformWin32()
+        public SQLitePlatformWin32(string nativeInteropSearchPath = null)
         {
-            SQLiteApi = new SQLiteApiWin32();
+            SQLiteApi = new SQLiteApiWin32(nativeInteropSearchPath);
             StopwatchFactory = new StopwatchFactoryWin32();
             ReflectionService = new ReflectionServiceWin32();
             VolatileService = new VolatileServiceWin32();

--- a/src/SQLite.Net.Platform.Win32/SQliteApiWin32Internal.cs
+++ b/src/SQLite.Net.Platform.Win32/SQliteApiWin32Internal.cs
@@ -10,19 +10,42 @@ namespace SQLite.Net.Platform.Win32
     {
         static SQLiteApiWin32Internal()
         {
-            // load native library
             int ptrSize = IntPtr.Size;
-            string relativePath = ptrSize == 8 ? @"x64\SQLite.Interop.dll" : @"x86\SQLite.Interop.dll";
-            string assemblyCurrentPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            string assemblyInteropPath = Path.Combine(assemblyCurrentPath, relativePath);
+            var architectureDirectory = (ptrSize == 8 ? "x64" : "x86");
+            var interopFilename = "SQLite.Interop.dll";
 
-            // try relative to assembly first, if that does not exist try relative to working dir
-            string interopPath = File.Exists(assemblyInteropPath) ? assemblyInteropPath : relativePath;
+            string interopPath = null;
+            if (!string.IsNullOrWhiteSpace(SQLiteApiWin32InternalConfiguration.NativeInteropSearchPath))
+            {
+                // a NativeInteropSearchPath is given, so we try to find the file name there
+                var fileInSearchPath = Path.Combine(SQLiteApiWin32InternalConfiguration.NativeInteropSearchPath, interopFilename);
+                if (File.Exists(fileInSearchPath))
+                {
+                    interopPath = fileInSearchPath;
+                }
+                else
+                {
+                    var fileInSearchPathWithArchitecture = Path.Combine(SQLiteApiWin32InternalConfiguration.NativeInteropSearchPath, architectureDirectory, interopFilename);
+                    if (File.Exists(fileInSearchPathWithArchitecture))
+                        interopPath = fileInSearchPathWithArchitecture;
+                }
+            }
+
+            if (interopPath == null)
+            {
+                // no NativeInteropSearchPath given (or nothing found using this path) so load native library from assembly execution direcotry
+                string assemblyCurrentPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                string relativePath = architectureDirectory + "\\" + interopFilename;
+                string assemblyInteropPath = Path.Combine(assemblyCurrentPath, architectureDirectory, interopFilename);
+
+                // try relative to assembly first, if that does not exist try relative to working dir
+                interopPath = File.Exists(assemblyInteropPath) ? assemblyInteropPath : relativePath;                
+            }
 
             IntPtr ret = LoadLibrary(interopPath);
             if (ret == IntPtr.Zero)
             {
-                throw new Exception("Failed to load native sqlite library");
+                throw new Exception("Failed to load native sqlite library from " + interopPath);
             }
         }
 


### PR DESCRIPTION
…o control where to search for the native interop dlls

this fixes the bug #95 that is marked as wontfix.

For some reason IIS copies the assemblies to some temp folder where the path resolution won't work any more. With this fix one can optionally set the search path. 

If no search path is set SQLite-net will behave as before