### PR TITLE
Split SQLite.Net so that other platforms can be created

### DIFF
--- a/nuget/SQLite.Net.Core.nuspec
+++ b/nuget/SQLite.Net.Core.nuspec
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
-        <id>SQLite.Net.Async-PCL</id>
+        <id>SQLite.Net.Core-PCL</id>
         <version>3.0.5</version>
-        <title>SQLite.Net.Async PCL</title>
+        <title>SQLite.Net PCL</title>
         <authors>Øystein Krog,Frank Krueger,Tim Heuer</authors>
         <owners>Øystein Krog</owners>
         <licenseUrl>https://raw.github.com/oysteinkrog/SQLite.Net-PCL/master/LICENSE.txt</licenseUrl>
@@ -11,16 +11,15 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>SQLite.Net PCL is an open source, minimal library to allow .NET and Mono applications to store data in SQLite databases.
             This is a fork of the original sqlite-net project, which aims to cleanup/improve the code and deliver the package as PCL assemblies with some additional platform-specific implementations.
-            This package is compatible with the following .net platforms: net4+sl5+wp8+win8+monotouch+monoAndroid</description>
-        <summary>A .NET client library to access SQLite embedded database files in a LINQ manner.
-            This package provides Async extensions to the core SQLite.Net package.</summary>
+            This package is compatible with the following .net platforms: Xamarin.iOS (Classic), Xamarin.iOS (Unified), Xamarin.Android, Windows Phone 8.1, Windows Phone 8.0, Windows 8.1, Windows 8.0, Win32, Generic, PCL(net4+sl4+wp7+win8+monotouch+MonoAndroid)</description>
+        <summary>A .NET client library to access SQLite embedded database files in a LINQ manner.</summary>
         <releaseNotes>https://github.com/oysteinkrog/SQLite.Net-PCL/commits</releaseNotes>
         <tags>sqlite pcl sql database ios android windows metro winrt xamarin monotouch monodroid win32 windowsphone wp wp8 wp8.1</tags>
         <dependencies>
-            <dependency id="SQLite.Net.Core-PCL" version="3.0.5"/>
         </dependencies>
     </metadata>
     <files>
-        <file src="SQLite.Net.Async\SQLite.Net.Async.dll" target="lib\portable-win8+net45+wp8+wpa81+MonoAndroid1+MonoTouch1\SQLite.Net.Async.dll" />
+        <!-- PCL -->
+        <file src="SQLite.Net\SQLite.Net.dll" target="lib\portable-win8+net45+wp8+wpa81+MonoAndroid1+MonoTouch1\SQLite.Net.dll" />
     </files>
 </package>

--- a/nuget/SQLite.Net.nuspec
+++ b/nuget/SQLite.Net.nuspec
@@ -19,46 +19,40 @@
             <group targetFramework="wp8">
                 <dependency id="sqlite-net-wp8" version="3.8.5"/>
             </group>
+            <group>
+		        <dependency id="SQLite.Net.Core-PCL" version="3.0.5"/>
+            </group>
         </dependencies>
     </metadata>
     <files>
         <!-- Xamarin.iOS (Classic)-->
-        <file src="SQLite.Net\SQLite.Net.dll" target="lib\monotouch\SQLite.Net.dll" />        
         <file src="SQLite.Net.Platform.XamarinIOS\SQLite.Net.Platform.XamarinIOS.dll" target="lib\monotouch\SQLite.Net.Platform.XamarinIOS.dll" />
 
         <!-- Xamarin.iOS (Unified)-->
-        <file src="SQLite.Net\SQLite.Net.dll" target="lib\Xamarin.iOS10\SQLite.Net.dll" />  
         <file src="SQLite.Net.Platform.XamarinIOS.Unified\SQLite.Net.Platform.XamarinIOS.Unified.dll" target="lib\Xamarin.iOS10\SQLite.Net.Platform.XamarinIOS.Unified.dll" />
 
         <!-- Xamarin.Android -->
-        <file src="SQLite.Net\SQLite.Net.dll" target="lib\MonoAndroid\SQLite.Net.dll" />
         <file src="SQLite.Net.Platform.XamarinAndroid\SQLite.Net.Platform.XamarinAndroid.dll" target="lib\MonoAndroid\SQLite.Net.Platform.XamarinAndroid.dll" />
 
         <!-- Windows Phone & Windows 8.1 -->
-        <file src="SQLite.Net\SQLite.Net.dll" target="lib\portable-win81+wpa81\SQLite.Net.dll" />
         <file src="SQLite.Net.Platform.WinRT\SQLite.Net.Platform.WinRT.dll" target="lib\portable-win81+wpa81\SQLite.Net.Platform.WinRT.dll" />
 
         <!-- Windows 8.0 -->
-        <file src="SQLite.Net\SQLite.Net.dll" target="lib\Windows8\SQLite.Net.dll" />
         <file src="SQLite.Net.Platform.WinRT\SQLite.Net.Platform.WinRT.dll" target="lib\Windows8\SQLite.Net.Platform.WinRT.dll" />
 
         <!-- Windows Phone 8.0 (ARM) -->
-        <file src="SQLite.Net\SQLite.Net.dll" target="lib\windowsphone8\ARM\SQLite.Net.dll" />
         <file src="SQLite.Net.Platform.WindowsPhone8\ARM\SQLite.Net.Platform.WindowsPhone8.dll" target="lib\windowsphone8\ARM\SQLite.Net.Platform.WindowsPhone8.dll" />
 
         <!-- Windows Phone 8.0 (x86) -->
-        <file src="SQLite.Net\SQLite.Net.dll" target="lib\windowsphone8\x86\SQLite.Net.dll" />
         <file src="SQLite.Net.Platform.WindowsPhone8\x86\SQLite.Net.Platform.WindowsPhone8.dll" target="lib\windowsphone8\x86\SQLite.Net.Platform.WindowsPhone8.dll" />
 
         <!-- Win32 -->
-        <file src="SQLite.Net\SQLite.Net.dll" target="lib\net4\SQLite.Net.dll" />
         <file src="SQLite.Net.Platform.Win32\SQLite.Net.Platform.Win32.dll" target="lib\net4\SQLite.Net.Platform.Win32.dll" />
 
         <!-- Generic -->
-        <file src="SQLite.Net\SQLite.Net.dll" target="lib\net40\SQLite.Net.dll" />
         <file src="SQLite.Net.Platform.Generic\SQLite.Net.Platform.Generic.dll" target="lib\net40\SQLite.Net.Platform.Generic.dll"/>
 
         <!-- PCL -->
-        <file src="SQLite.Net\SQLite.Net.dll" target="lib\portable-win8+net45+wp8+wpa81+MonoAndroid1+MonoTouch1\SQLite.Net.dll" />
+        <file src="SQLite.Net\_._" target="lib\portable-win8+net45+wp8+wpa81+MonoAndroid1+MonoTouch1\_._" />
     </files>
 </package>

--- a/nuget/build.bat
+++ b/nuget/build.bat
@@ -1,3 +1,4 @@
 @mkdir output
+..\.nuget\nuget pack SQLite.Net.Core.nuspec -o output
 ..\.nuget\nuget pack SQLite.Net.nuspec -o output
 ..\.nuget\nuget pack SQLite.Net.Async.nuspec -o output

--- a/nuget/prepare.bat
+++ b/nuget/prepare.bat
@@ -1,5 +1,6 @@
 mkdir SQLite.Net
 copy /y ..\src\SQLite.Net\bin\Release\SQLite.Net.dll SQLite.Net
+type nul >SQLite.Net\_._
 
 mkdir SQLite.Net.Async
 copy /y ..\src\SQLite.Net.Async\bin\Release\SQLite.Net.Async.dll SQLite.Net.Async

--- a/nuget/upload.bat
+++ b/nuget/upload.bat
@@ -1,2 +1,3 @@
+..\.nuget\nuget push output\SQLite.Net.Core-PCL.3.0.5.nupkg
 ..\.nuget\nuget push output\SQLite.Net-PCL.3.0.5.nupkg
 ..\.nuget\nuget push output\SQLite.Net.Async-PCL.3.0.5.nupkg


### PR DESCRIPTION
 - SQLite.Net still functions as before, but the SQLite.Net.dll was moved out
 - SQLite.Net.Core now contains the SQLite.Net.dll
 - SQLite.Net.Async now depends on SQLite.Net.Core

This is a solution relating to #201 and #207 