### PR TITLE
Autoincrement is automatic if an ID <> 0 is set

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,8 @@
+##########################################################
+#### WhiteSource "Bolt for Github" configuration file ####
+##########################################################
+
+# Configuration #
+#---------------#
+ws.repo.scan=true
+vulnerable.check.run.conclusion.level=failure

--- a/src/SQLite.Net/SQLiteConnection.cs
+++ b/src/SQLite.Net/SQLiteConnection.cs
@@ -1477,9 +1477,33 @@ namespace SQLite.Net
                 }
             }
 
+            bool usePkValue = false;
+            if (map.PK != null && map.PK.IsAutoInc)
+            {
+                var prop = objType.GetRuntimeProperty(map.PK.PropertyName);
+                if (prop != null)
+                {
+                    var val = prop.GetValue(obj);
+                    if (val != null && val.ToString() != "0")
+                    {
+                        usePkValue = true;
+                    }
+                }
+            }
+
             var replacing = string.Compare(extra, "OR REPLACE", StringComparison.OrdinalIgnoreCase) == 0;
 
-            var cols = replacing ? map.Columns : map.InsertColumns;
+            TableMapping.Column[] cols;
+
+            if (usePkValue)
+            {
+                cols = replacing ? map.Columns : map.InsertColumnsWithPk;
+            }
+            else
+            {
+                cols = replacing ? map.Columns : map.InsertColumns;
+            }
+            
             var vals = new object[cols.Length];
             for (var i = 0; i < vals.Length; i++)
             {

--- a/src/SQLite.Net/TableMapping.cs
+++ b/src/SQLite.Net/TableMapping.cs
@@ -105,6 +105,13 @@ namespace SQLite.Net
         {
             get { return _insertColumns ?? (_insertColumns = Columns.Where(c => !c.IsAutoInc).ToArray()); }
         }
+        
+        [PublicAPI]
+        public Column[] InsertColumnsWithPk
+        {
+            get { return _insertColumns ?? (_insertColumns = Columns.ToArray()); }
+        }
+
 
         [PublicAPI]
         public void SetAutoIncPK(object obj, long id)


### PR DESCRIPTION
If i use a primary key with value <> 0, the wrapper override this value and autoincrement automaticaly, but in some situation, it's voluntary set (synchro with database offline with same id, for example).
