### PR TITLE
Allowing SQLiteAPiWinRT to receive explicit address for temp folder.

### DIFF
--- a/src/SQLite.Net.Platform.WinRT/SQLiteApiWinRT.cs
+++ b/src/SQLite.Net.Platform.WinRT/SQLiteApiWinRT.cs
@@ -9,9 +9,9 @@ namespace SQLite.Net.Platform.WinRT
 {
     public class SQLiteApiWinRT : ISQLiteApiExt
     {
-        public SQLiteApiWinRT()
+        public SQLiteApiWinRT(string tempFolderPath = null)
         {
-            SQLite3.SetDirectory(/*temp directory type*/2, Windows.Storage.ApplicationData.Current.TemporaryFolder.Path);
+            SQLite3.SetDirectory(/*temp directory type*/2, tempFolderPath ?? Windows.Storage.ApplicationData.Current.TemporaryFolder.Path);
         }
 
         public int BindBlob(IDbStatement stmt, int index, byte[] val, int n, IntPtr free)

--- a/src/SQLite.Net.Platform.WinRT/SQLitePlatformWinRT.cs
+++ b/src/SQLite.Net.Platform.WinRT/SQLitePlatformWinRT.cs
@@ -5,9 +5,9 @@ namespace SQLite.Net.Platform.WinRT
 {
     public class SQLitePlatformWinRT : ISQLitePlatform
     {
-        public SQLitePlatformWinRT()
+        public SQLitePlatformWinRT(string tempFolderPath = null)
         {
-            SQLiteApi = new SQLiteApiWinRT();
+            SQLiteApi = new SQLiteApiWinRT(tempFolderPath);
             VolatileService = new VolatileServiceWinRT();
             StopwatchFactory = new StopwatchFactoryWinRT();
             ReflectionService = new ReflectionServiceWinRT();


### PR DESCRIPTION
Allowing SQLiteAPiWinRT to receive address for temp folder. For class-library based test projects there is no Application.Current so the old code would break as it was trying to get the temp folder for the current app. Fixing issue #229 