### PR TITLE
some change.

### DIFF
--- a/src/SQLite.Net/ITableMappingManager.cs
+++ b/src/SQLite.Net/ITableMappingManager.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using SQLite.Net.Interop;
+
+namespace SQLite.Net
+{
+    public interface ITableMappingManager
+    {
+        IDictionary<Type, string> ExtraTypeMappings { get; }
+
+        IEnumerable<TableMapping> TableMappings { get; }
+
+        TableMapping GetMapping(Type type, CreateFlags createFlags = CreateFlags.None);
+    }
+}

--- a/src/SQLite.Net/PropertyExtensions.cs
+++ b/src/SQLite.Net/PropertyExtensions.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace SQLite.Net
+{
+    internal static class PropertyExtensions
+    {
+        public interface IAccessor { }
+
+        public interface IGetter : IAccessor
+        {
+            object Get(object instance);
+
+            object this[object instance] { get; }
+        }
+
+        public class Getter<TObject, TMember> : IGetter
+        {
+            private readonly Func<TObject, TMember> getter;
+
+            public Getter([NotNull] Func<TObject, TMember> getter)
+            {
+                if (getter == null) throw new ArgumentNullException(nameof(getter));
+                this.getter = getter;
+            }
+
+            public TMember Get(TObject obj) => this.getter(obj);
+
+            public TMember this[TObject obj] => this.Get(obj);
+
+            #region Implementation of IGetter
+
+            public object Get(object instance) => this.getter((TObject)instance);
+
+            public object this[object instance] => this.Get(instance);
+
+            #endregion
+
+            public static implicit operator Func<TObject, TMember>(Getter<TObject, TMember> self) => self?.getter;
+        }
+
+        public interface ISetter : IAccessor
+        {
+            void Set(object instance, object value);
+
+            object this[object obj] { set; }
+        }
+
+        public class Setter<TObject, TMember> : ISetter
+        {
+            private readonly Action<TObject, TMember> setter;
+
+            public Setter([NotNull] Action<TObject, TMember> setter)
+            {
+                if (setter == null) throw new ArgumentNullException(nameof(setter));
+                this.setter = setter;
+            }
+
+            public void Set(TObject obj, TMember value) => this.setter(obj, value);
+
+            public TMember this[TObject obj]
+            {
+                set { this.Set(obj, value); }
+            }
+
+            #region Implementation of ISetter
+
+            public void Set(object instance, object value) => this.setter((TObject)instance, (TMember)value);
+
+            public object this[object obj]
+            {
+                set { this.Set(obj, value); }
+            }
+
+            #endregion
+
+            public static implicit operator Action<TObject, TMember>(Setter<TObject, TMember> self) => self?.setter;
+        }
+
+        public static Getter<TObject, TProperty> CompileGetter<TObject, TProperty>([NotNull] this PropertyInfo property)
+        {
+            if (property == null) throw new ArgumentNullException(nameof(property));
+            if (typeof(TObject) != property.DeclaringType) throw new InvalidOperationException();
+            if (typeof(TProperty) != property.PropertyType) throw new InvalidOperationException();
+
+            var argObj = Expression.Parameter(typeof(TObject));
+            var accessor = Expression.Property(argObj, property);
+            return new Getter<TObject, TProperty>(Expression.Lambda<Func<TObject, TProperty>>(accessor, argObj).Compile());
+        }
+
+        public static Getter<object, object> CompileGetter([NotNull] this PropertyInfo property)
+        {
+            if (property == null) throw new ArgumentNullException(nameof(property));
+
+            var obj = Expression.Parameter(typeof(object));
+            var accessor = Expression.MakeMemberAccess(Expression.Convert(obj, property.DeclaringType), property);
+            return new Getter<object, object>(
+                Expression.Lambda<Func<object, object>>(Expression.Convert(accessor, typeof(object)), obj
+                    ).Compile());
+        }
+
+        public static Setter<TObject, TProperty> CompileSetter<TObject, TProperty>([NotNull] this PropertyInfo property)
+        {
+            if (property == null) throw new ArgumentNullException(nameof(property));
+            if (typeof(TObject) != property.DeclaringType) throw new InvalidOperationException();
+            if (typeof(TProperty) != property.PropertyType) throw new InvalidOperationException();
+
+            var argObj = Expression.Parameter(typeof(TObject));
+            var argInput = Expression.Parameter(typeof(TProperty));
+            var accessor = Expression.Property(argObj, property);
+            var assign = Expression.Assign(accessor, argInput);
+            return new Setter<TObject, TProperty>(Expression.Lambda<Action<TObject, TProperty>>(assign, argObj, argInput).Compile());
+        }
+
+        public static Setter<object, object> CompileSetter([NotNull] this PropertyInfo property)
+        {
+            if (property == null) throw new ArgumentNullException(nameof(property));
+
+            var obj = Expression.Parameter(typeof(object));
+            var value = Expression.Parameter(typeof(object));
+            var accessor = Expression.Property(Expression.Convert(obj, property.DeclaringType), property);
+            var assign = Expression.Assign(accessor, Expression.Convert(value, property.PropertyType));
+            return new Setter<object, object>(Expression.Lambda<Action<object, object>>(assign, obj, value).Compile());
+        }
+    }
+}

--- a/src/SQLite.Net/SQLite.Net.csproj
+++ b/src/SQLite.Net/SQLite.Net.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Interop\Result.cs" />
     <Compile Include="Interop\IDbStatement.cs" />
     <Compile Include="IBlobSerializer.cs" />
+    <Compile Include="ITableMappingManager.cs" />
     <Compile Include="NotNullConstraintViolationException.cs" />
     <Compile Include="Orm.cs" />
     <Compile Include="PreparedSqlLiteInsertCommand.cs" />
@@ -107,6 +108,7 @@
     <Compile Include="SQLiteConnectionString.cs" />
     <Compile Include="SQLiteConnectionWithLock.cs" />
     <Compile Include="TableMapping.cs" />
+    <Compile Include="TableMappingManager.cs" />
     <Compile Include="TableQuery.cs" />
     <Compile Include="Interop\SQLiteOpenFlags.cs" />
     <Compile Include="Attributes\TableAttribute.cs" />

--- a/src/SQLite.Net/SQLite.Net.csproj
+++ b/src/SQLite.Net/SQLite.Net.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Attributes\IndexedAttribute.cs" />
     <Compile Include="Attributes\MaxLengthAttribute.cs" />
     <Compile Include="Attributes\PrimaryKeyAttribute.cs" />
+    <Compile Include="PropertyExtensions.cs" />
     <Compile Include="SQLiteException.cs" />
     <Compile Include="SQLiteCommand.cs" />
     <Compile Include="SQLiteConnection.cs" />

--- a/src/SQLite.Net/SQLiteConnection.cs
+++ b/src/SQLite.Net/SQLiteConnection.cs
@@ -1491,13 +1491,9 @@ namespace SQLite.Net
 
             if (map.PK != null && map.PK.IsAutoGuid)
             {
-                var prop = objType.GetRuntimeProperty(map.PK.PropertyName);
-                if (prop != null)
+                if (map.PK.GetValue(obj).Equals(Guid.Empty))
                 {
-                    if (prop.GetValue(obj, null).Equals(Guid.Empty))
-                    {
-                        prop.SetValue(obj, Guid.NewGuid(), null);
-                    }
+                    map.PK.SetValue(obj, Guid.NewGuid());
                 }
             }
 

--- a/src/SQLite.Net/SQLiteConnection.cs
+++ b/src/SQLite.Net/SQLiteConnection.cs
@@ -51,8 +51,6 @@ namespace SQLite.Net
         private static bool _preserveDuringLinkMagic;
 #pragma warning restore 649
         private readonly Random _rand = new Random();
-        private readonly IDictionary<string, TableMapping> _tableMappings;
-		private readonly object _tableMappingsLocks;
         private TimeSpan _busyTimeout;
         private long _elapsedMilliseconds;
         private IDictionary<TableMapping, ActiveInsertCommand> _insertCommandCache;
@@ -100,10 +98,14 @@ namespace SQLite.Net
         ///     A contract resovler for resolving interfaces to concreate types during object creation
         /// </param>
         [PublicAPI]
-        public SQLiteConnection([JetBrains.Annotations.NotNull] ISQLitePlatform sqlitePlatform, [JetBrains.Annotations.NotNull] string databasePath,
-            bool storeDateTimeAsTicks = true, [CanBeNull] IBlobSerializer serializer = null, [CanBeNull] IDictionary<string, TableMapping> tableMappings = null,
-            [CanBeNull] IDictionary<Type, string> extraTypeMappings = null, [CanBeNull] IContractResolver resolver = null)
-            : this(sqlitePlatform, databasePath, SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create, storeDateTimeAsTicks,
+        public SQLiteConnection([JetBrains.Annotations.NotNull] ISQLitePlatform sqlitePlatform,
+            [JetBrains.Annotations.NotNull] string databasePath,
+            bool storeDateTimeAsTicks = true, [CanBeNull] IBlobSerializer serializer = null,
+            [CanBeNull] IDictionary<string, TableMapping> tableMappings = null,
+            [CanBeNull] IDictionary<Type, string> extraTypeMappings = null,
+            [CanBeNull] IContractResolver resolver = null)
+            : this(
+                sqlitePlatform, databasePath, SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create, storeDateTimeAsTicks,
                 serializer, tableMappings, extraTypeMappings, resolver)
         {
         }
@@ -139,21 +141,31 @@ namespace SQLite.Net
         ///     A contract resovler for resolving interfaces to concreate types during object creation
         /// </param>
         [PublicAPI]
-        public SQLiteConnection([JetBrains.Annotations.NotNull] ISQLitePlatform sqlitePlatform, string databasePath, SQLiteOpenFlags openFlags,
-            bool storeDateTimeAsTicks = true, [CanBeNull] IBlobSerializer serializer = null, [CanBeNull] IDictionary<string, TableMapping> tableMappings = null,
+        public SQLiteConnection([JetBrains.Annotations.NotNull] ISQLitePlatform sqlitePlatform, string databasePath,
+            SQLiteOpenFlags openFlags, bool storeDateTimeAsTicks = true, [CanBeNull] IBlobSerializer serializer = null,
+            [CanBeNull] IDictionary<string, TableMapping> tableMappings = null,
             [CanBeNull] IDictionary<Type, string> extraTypeMappings = null, IContractResolver resolver = null)
+            : this(sqlitePlatform, databasePath, openFlags, storeDateTimeAsTicks, serializer,
+                new TableMappingManager(sqlitePlatform, tableMappings, extraTypeMappings),
+                resolver)
+        {
+        }
+
+        [PublicAPI]
+        public SQLiteConnection([JetBrains.Annotations.NotNull] ISQLitePlatform sqlitePlatform, string databasePath,
+            SQLiteOpenFlags openFlags, bool storeDateTimeAsTicks = true,
+            [CanBeNull] IBlobSerializer serializer = null,
+            [CanBeNull] ITableMappingManager tableMappingManager = null,
+            [CanBeNull] IContractResolver resolver = null)
         {
             if (sqlitePlatform == null)
             {
                 throw new ArgumentNullException("sqlitePlatform");
             }
-            ExtraTypeMappings = extraTypeMappings ?? new Dictionary<Type, string>();
+            this.TableMappingManager = tableMappingManager ?? new TableMappingManager(sqlitePlatform);
             Serializer = serializer;
             Platform = sqlitePlatform;
             Resolver = resolver ?? ContractResolver.Current;
-
-            _tableMappings = tableMappings ?? new Dictionary<string, TableMapping>();
-			_tableMappingsLocks = new object();
 
             if (string.IsNullOrEmpty(databasePath))
             {
@@ -164,7 +176,7 @@ namespace SQLite.Net
 
             IDbHandle handle;
             var databasePathAsBytes = GetNullTerminatedUtf8(DatabasePath);
-            var r = Platform.SQLiteApi.Open(databasePathAsBytes, out handle, (int) openFlags, IntPtr.Zero);
+            var r = Platform.SQLiteApi.Open(databasePathAsBytes, out handle, (int)openFlags, IntPtr.Zero);
 
             Handle = handle;
             if (r != Result.OK)
@@ -186,6 +198,8 @@ namespace SQLite.Net
             BusyTimeout = TimeSpan.FromSeconds(0.1);
         }
 
+        public ITableMappingManager TableMappingManager { get; private set; }
+
         [CanBeNull, PublicAPI]
         public IBlobSerializer Serializer { get; private set; }
 
@@ -206,7 +220,10 @@ namespace SQLite.Net
         public bool StoreDateTimeAsTicks { get; private set; }
 
         [JetBrains.Annotations.NotNull, PublicAPI]
-        public IDictionary<Type, string> ExtraTypeMappings { get; private set; }
+        public IDictionary<Type, string> ExtraTypeMappings
+        {
+            get { return this.TableMappingManager.ExtraTypeMappings; }
+        }
 
         [JetBrains.Annotations.NotNull, PublicAPI]
         public IContractResolver Resolver { get; private set; }
@@ -224,7 +241,7 @@ namespace SQLite.Net
                 _busyTimeout = value;
                 if (Handle != NullHandle)
                 {
-                    Platform.SQLiteApi.BusyTimeout(Handle, (int) _busyTimeout.TotalMilliseconds);
+                    Platform.SQLiteApi.BusyTimeout(Handle, (int)_busyTimeout.TotalMilliseconds);
                 }
             }
         }
@@ -237,13 +254,7 @@ namespace SQLite.Net
         [JetBrains.Annotations.NotNull]
         public IEnumerable<TableMapping> TableMappings
         {
-            get
-			{
-				lock (_tableMappingsLocks)
-				{
-					return _tableMappings.Values.ToList();
-				}
-			}
+            get { return this.TableMappingManager.TableMappings; }
         }
 
         /// <summary>
@@ -301,19 +312,7 @@ namespace SQLite.Net
         [PublicAPI]
         public TableMapping GetMapping(Type type, CreateFlags createFlags = CreateFlags.None)
         {
-			lock (_tableMappingsLocks)
-			{
-				TableMapping map;
-				return _tableMappings.TryGetValue(type.FullName, out map) ? map : CreateAndSetMapping(type, createFlags, _tableMappings);
-			}
-        }
-
-        private TableMapping CreateAndSetMapping(Type type, CreateFlags createFlags, IDictionary<string, TableMapping> mapTable)
-        {
-            var props = Platform.ReflectionService.GetPublicInstanceProperties(type);
-            var map = new TableMapping(type, props, createFlags);
-	            mapTable[type.FullName] = map;
-            	return map;
+            return this.TableMappingManager.GetMapping(type, createFlags);
         }
 
         /// <summary>
@@ -326,7 +325,7 @@ namespace SQLite.Net
         [PublicAPI]
         public TableMapping GetMapping<T>()
         {
-            return GetMapping(typeof (T));
+            return GetMapping(typeof(T));
         }
 
         /// <summary>
@@ -335,7 +334,7 @@ namespace SQLite.Net
         [PublicAPI]
         public int DropTable<T>()
         {
-            return DropTable(typeof (T));
+            return DropTable(typeof(T));
         }
 
         /// <summary>
@@ -363,7 +362,7 @@ namespace SQLite.Net
         [PublicAPI]
         public int CreateTable<T>(CreateFlags createFlags = CreateFlags.None)
         {
-            return CreateTable(typeof (T), createFlags);
+            return CreateTable(typeof(T), createFlags);
         }
 
         /// <summary>
@@ -473,7 +472,7 @@ namespace SQLite.Net
         [PublicAPI]
         public int CreateIndex(string indexName, string tableName, string columnName, bool unique = false)
         {
-            return CreateIndex(indexName, tableName, new[] {columnName}, unique);
+            return CreateIndex(indexName, tableName, new[] { columnName }, unique);
         }
 
         /// <summary>
@@ -513,7 +512,7 @@ namespace SQLite.Net
             MemberExpression mx;
             if (property.Body.NodeType == ExpressionType.Convert)
             {
-                mx = ((UnaryExpression) property.Body).Operand as MemberExpression;
+                mx = ((UnaryExpression)property.Body).Operand as MemberExpression;
             }
             else
             {
@@ -544,18 +543,18 @@ namespace SQLite.Net
             return Query<ColumnInfo>(query);
         }
 
-		[PublicAPI]
-		public void MigrateTable<T>()
-		{
-			MigrateTable(typeof(T));
-		}
+        [PublicAPI]
+        public void MigrateTable<T>()
+        {
+            MigrateTable(typeof(T));
+        }
 
-		[PublicAPI]
-		public void MigrateTable(Type t)
-		{
-			var map = GetMapping(t);
-			MigrateTable(map);
-		}
+        [PublicAPI]
+        public void MigrateTable(Type t)
+        {
+            var map = GetMapping(t);
+            MigrateTable(map);
+        }
 
         private void MigrateTable(TableMapping map)
         {
@@ -667,7 +666,7 @@ namespace SQLite.Net
                 _sw.Stop();
                 _elapsedMilliseconds += _sw.ElapsedMilliseconds;
 
-                TraceListener.WriteLine("Finished in {0} ms ({1:0.0} s total)", _sw.ElapsedMilliseconds, _elapsedMilliseconds/1000.0);
+                TraceListener.WriteLine("Finished in {0} ms ({1:0.0} s total)", _sw.ElapsedMilliseconds, _elapsedMilliseconds / 1000.0);
             }
 
             return r;
@@ -695,7 +694,7 @@ namespace SQLite.Net
                 _sw.Stop();
                 _elapsedMilliseconds += _sw.ElapsedMilliseconds;
 
-                TraceListener.WriteLine("Finished in {0} ms ({1:0.0} s total)", _sw.ElapsedMilliseconds, _elapsedMilliseconds/1000.0);
+                TraceListener.WriteLine("Finished in {0} ms ({1:0.0} s total)", _sw.ElapsedMilliseconds, _elapsedMilliseconds / 1000.0);
             }
 
             return r;
@@ -831,7 +830,7 @@ namespace SQLite.Net
         [PublicAPI]
         public T Get<T>(object pk) where T : class
         {
-            var map = GetMapping(typeof (T));
+            var map = GetMapping(typeof(T));
             return Query<T>(map.GetByPrimaryKeySql, pk).First();
         }
 
@@ -867,7 +866,7 @@ namespace SQLite.Net
         [PublicAPI]
         public T Find<T>(object pk) where T : class
         {
-            var map = GetMapping(typeof (T));
+            var map = GetMapping(typeof(T));
             return Query<T>(map.GetByPrimaryKeySql, pk).FirstOrDefault();
         }
 
@@ -1279,24 +1278,25 @@ namespace SQLite.Net
         }
 
         [PublicAPI]
-        public int InsertOrIgnoreAll (IEnumerable objects)
+        public int InsertOrIgnoreAll(IEnumerable objects)
         {
-            return InsertAll (objects, "OR IGNORE");
+            return InsertAll(objects, "OR IGNORE");
         }
 
         [PublicAPI]
-        public int InsertOrIgnore (object obj)
+        public int InsertOrIgnore(object obj)
         {
-            if (obj == null) {
+            if (obj == null)
+            {
                 return 0;
             }
-            return Insert (obj, "OR IGNORE", obj.GetType ());
+            return Insert(obj, "OR IGNORE", obj.GetType());
         }
 
         [PublicAPI]
-        public int InsertOrIgnore (object obj, Type objType)
+        public int InsertOrIgnore(object obj, Type objType)
         {
-            return Insert (obj, "OR IGNORE", objType);
+            return Insert(obj, "OR IGNORE", objType);
         }
 
         /// <summary>
@@ -1605,17 +1605,17 @@ namespace SQLite.Net
             }
 
             var cols = from p in map.Columns
-                where p != pk
-                select p;
+                       where p != pk
+                       select p;
             var vals = from c in cols
-                select c.GetValue(obj);
+                       select c.GetValue(obj);
             var ps = new List<object>(vals)
             {
                 pk.GetValue(obj)
             };
             var q = string.Format("update \"{0}\" set {1} where {2} = ? ", map.TableName,
                 string.Join(",", (from c in cols
-                    select "\"" + c.Name + "\" = ? ").ToArray()), pk.Name);
+                                  select "\"" + c.Name + "\" = ? ").ToArray()), pk.Name);
             try
             {
                 rowsAffected = Execute(q, ps.ToArray());
@@ -1704,7 +1704,7 @@ namespace SQLite.Net
         [PublicAPI]
         public int Delete<T>(object primaryKey)
         {
-            var map = GetMapping(typeof (T));
+            var map = GetMapping(typeof(T));
             var pk = map.PK;
             if (pk == null)
             {
@@ -1728,7 +1728,7 @@ namespace SQLite.Net
         [PublicAPI]
         public int DeleteAll<T>()
         {
-            return DeleteAll(typeof (T));
+            return DeleteAll(typeof(T));
         }
 
         /// <summary>
@@ -1763,7 +1763,7 @@ namespace SQLite.Net
             IDbHandle destDB;
             byte[] databasePathAsBytes = GetNullTerminatedUtf8(destDBPath);
             Result r = sqliteApi.Open(databasePathAsBytes, out destDB,
-                (int) (SQLiteOpenFlags.Create | SQLiteOpenFlags.ReadWrite), IntPtr.Zero);
+                (int)(SQLiteOpenFlags.Create | SQLiteOpenFlags.ReadWrite), IntPtr.Zero);
 
             if (r != Result.OK)
             {

--- a/src/SQLite.Net/TableMapping.cs
+++ b/src/SQLite.Net/TableMapping.cs
@@ -212,32 +212,15 @@ namespace SQLite.Net
             public void SetValue(object obj, [CanBeNull] object val)
             {
                 var propType = _prop.PropertyType;
-                var typeInfo = propType.GetTypeInfo();
 
-                if (typeInfo.IsGenericType && propType.GetGenericTypeDefinition() == typeof(Nullable<>))
+                var enumType = Nullable.GetUnderlyingType(propType) ?? propType;
+                if (enumType.GetTypeInfo().IsEnum)
                 {
-                    var typeCol = propType.GetTypeInfo().GenericTypeArguments;
-                    if (typeCol.Length > 0)
-                    {
-                        var nullableType = typeCol[0];
-                        var baseType = nullableType.GetTypeInfo().BaseType;
-                        if (baseType == typeof(Enum))
-                        {
-                            SetEnumValue(obj, nullableType, val);
-                        }
-                        else
-                        {
-                            _prop.SetValue(obj, val, null);
-                        }
-                    }
-                }
-                else if (typeInfo.BaseType == typeof(Enum))
-                {
-                    SetEnumValue(obj, propType, val);
+                    this.SetEnumValue(obj, enumType, val);
                 }
                 else
                 {
-                    _prop.SetValue(obj, val, null);
+                    this._prop.SetValue(obj, val, null);
                 }
             }
 

--- a/src/SQLite.Net/TableMapping.cs
+++ b/src/SQLite.Net/TableMapping.cs
@@ -49,9 +49,8 @@ namespace SQLite.Net
             var cols = new List<Column>();
             foreach (var p in props)
             {
-                var ignore = p.IsDefined(typeof(IgnoreAttribute), true);
-
-                if (p.CanWrite && !ignore)
+                if (p.CanWrite && p.CanRead && !p.IsDefined(typeof(IgnoreAttribute), true) &&
+                    !(p.CanRead ? p.GetMethod : p.SetMethod).IsStatic) // sure is not static property
                 {
                     cols.Add(new Column(p, createFlags));
                 }

--- a/src/SQLite.Net/TableMapping.cs
+++ b/src/SQLite.Net/TableMapping.cs
@@ -42,14 +42,14 @@ namespace SQLite.Net
 
             var tableAttr = type.GetTypeInfo().GetCustomAttributes<TableAttribute>().FirstOrDefault();
 
-            TableName = tableAttr != null ?  tableAttr.Name : MappedType.Name;
+            TableName = tableAttr != null ? tableAttr.Name : MappedType.Name;
 
             var props = properties;
 
             var cols = new List<Column>();
             foreach (var p in props)
             {
-                var ignore = p.IsDefined(typeof (IgnoreAttribute), true);
+                var ignore = p.IsDefined(typeof(IgnoreAttribute), true);
 
                 if (p.CanWrite && !ignore)
                 {
@@ -151,7 +151,7 @@ namespace SQLite.Net
 
                 var isAuto = Orm.IsAutoInc(prop) ||
                              (IsPK && ((createFlags & CreateFlags.AutoIncPK) == CreateFlags.AutoIncPK));
-                IsAutoGuid = isAuto && ColumnType == typeof (Guid);
+                IsAutoGuid = isAuto && ColumnType == typeof(Guid);
                 IsAutoInc = isAuto && !IsAutoGuid;
 
                 DefaultValue = Orm.GetDefaultValue(prop);
@@ -162,7 +162,7 @@ namespace SQLite.Net
                     && ((createFlags & CreateFlags.ImplicitIndex) == CreateFlags.ImplicitIndex)
                     && Name.EndsWith(Orm.ImplicitIndexSuffix, StringComparison.OrdinalIgnoreCase))
                 {
-                    Indices = new[] {new IndexedAttribute()};
+                    Indices = new[] { new IndexedAttribute() };
                 }
                 IsNullable = !(IsPK || Orm.IsMarkedNotNull(prop));
                 MaxStringLength = Orm.MaxStringLength(prop);
@@ -215,14 +215,14 @@ namespace SQLite.Net
                 var propType = _prop.PropertyType;
                 var typeInfo = propType.GetTypeInfo();
 
-                if (typeInfo.IsGenericType && propType.GetGenericTypeDefinition() == typeof (Nullable<>))
+                if (typeInfo.IsGenericType && propType.GetGenericTypeDefinition() == typeof(Nullable<>))
                 {
                     var typeCol = propType.GetTypeInfo().GenericTypeArguments;
                     if (typeCol.Length > 0)
                     {
                         var nullableType = typeCol[0];
                         var baseType = nullableType.GetTypeInfo().BaseType;
-                        if (baseType == typeof (Enum))
+                        if (baseType == typeof(Enum))
                         {
                             SetEnumValue(obj, nullableType, val);
                         }
@@ -232,7 +232,7 @@ namespace SQLite.Net
                         }
                     }
                 }
-                else if (typeInfo.BaseType == typeof (Enum))
+                else if (typeInfo.BaseType == typeof(Enum))
                 {
                     SetEnumValue(obj, propType, val);
                 }

--- a/src/SQLite.Net/TableMappingManager.cs
+++ b/src/SQLite.Net/TableMappingManager.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using SQLite.Net.Interop;
+
+namespace SQLite.Net
+{
+    public class TableMappingManager : ITableMappingManager
+    {
+        private readonly IDictionary<string, TableMapping> _tableMappings;
+        private readonly object _tableMappingsLocks = new object();
+
+        public TableMappingManager(
+            [NotNull] ISQLitePlatform sqlitePlatform,
+            [CanBeNull] IDictionary<string, TableMapping> tableMappings = null,
+            [CanBeNull] IDictionary<Type, string> extraTypeMappings = null)
+        {
+            this.Platform = sqlitePlatform;
+            this.ExtraTypeMappings = extraTypeMappings ?? new Dictionary<Type, string>();
+            this._tableMappings = tableMappings ?? new Dictionary<string, TableMapping>();
+        }
+
+        /// <summary>
+        ///     Retrieves the mapping that is automatically generated for the given type.
+        /// </summary>
+        /// <param name="type">
+        ///     The type whose mapping to the database is returned.
+        /// </param>
+        /// <param name="createFlags">
+        ///     Optional flags allowing implicit PK and indexes based on naming conventions
+        /// </param>
+        /// <returns>
+        ///     The mapping represents the schema of the columns of the database and contains
+        ///     methods to set and get properties of objects.
+        /// </returns>
+        [PublicAPI]
+        public TableMapping GetMapping(Type type, CreateFlags createFlags = CreateFlags.None)
+        {
+            lock (this._tableMappingsLocks)
+            {
+                TableMapping map;
+                return this._tableMappings.TryGetValue(type.FullName, out map)
+                    ? map
+                    : this.CreateAndSetMapping(type, createFlags, this._tableMappings);
+            }
+        }
+
+        [NotNull, PublicAPI]
+        public ISQLitePlatform Platform { get; private set; }
+
+        private TableMapping CreateAndSetMapping(Type type, CreateFlags createFlags,
+            IDictionary<string, TableMapping> mapTable)
+        {
+            var props = this.Platform.ReflectionService.GetPublicInstanceProperties(type);
+            var map = new TableMapping(type, props, createFlags);
+            mapTable[type.FullName] = map;
+            return map;
+        }
+
+        /// <summary>
+        ///     Retrieves the mapping that is automatically generated for the given type.
+        /// </summary>
+        /// <returns>
+        ///     The mapping represents the schema of the columns of the database and contains
+        ///     methods to set and get properties of objects.
+        /// </returns>
+        [PublicAPI]
+        public TableMapping GetMapping<T>()
+        {
+            return this.GetMapping(typeof(T));
+        }
+
+        /// <summary>
+        ///     Returns the mappings from types to tables that the connection
+        ///     currently understands.
+        /// </summary>
+        [PublicAPI]
+        [NotNull]
+        public IEnumerable<TableMapping> TableMappings
+        {
+            get
+            {
+                lock (this._tableMappingsLocks)
+                {
+                    return this._tableMappings.Values.ToList();
+                }
+            }
+        }
+
+        public IDictionary<Type, string> ExtraTypeMappings { get; private set; }
+    }
+}


### PR DESCRIPTION
what change:
#### 1. higher performance

call GetValue() and SetValue() in reflection is very slow.
So I change to use Expression.Lambda().Compile() to make it faster like native.
#### 2. extract mapper

Type can not be change after it create. so all mapper of type should could reuse.
#### 3. ignore readonly property.

before this, the lib will raise a exception.
#### 4. ignore static property

emmm...

all test pass on Win32.
