### PR TITLE
Fix an issue that miscount length of a query including non-ascii characters

### DIFF
--- a/src/SQLite.Net.Platform.Generic/SQLiteApiGeneric.cs
+++ b/src/SQLite.Net.Platform.Generic/SQLiteApiGeneric.cs
@@ -71,7 +71,7 @@ namespace SQLite.Net.Platform.Generic
         {
             var internalDbHandle = (DbHandle) db;
             IntPtr stmt;
-            Result r = SQLiteApiGenericInternal.sqlite3_prepare_v2(internalDbHandle.DbPtr, query, query.Length, out stmt, IntPtr.Zero);
+            Result r = SQLiteApiGenericInternal.sqlite3_prepare_v2(internalDbHandle.DbPtr, query, -1, out stmt, IntPtr.Zero);
             if (r != Result.OK)
             {
                 throw SQLiteException.New(r, Errmsg16(internalDbHandle));

--- a/src/SQLite.Net.Platform.OSX/SQLiteApiOSX.cs
+++ b/src/SQLite.Net.Platform.OSX/SQLiteApiOSX.cs
@@ -73,7 +73,7 @@ namespace SQLite.Net.Platform.OSX
         {
             var internalDbHandle = (DbHandle) db;
             IntPtr stmt;
-            Result r = SQLiteApiOSXInternal.sqlite3_prepare_v2(internalDbHandle.DbPtr, query, query.Length, out stmt, IntPtr.Zero);
+            Result r = SQLiteApiOSXInternal.sqlite3_prepare_v2(internalDbHandle.DbPtr, query, -1, out stmt, IntPtr.Zero);
             if (r != Result.OK)
             {
                 throw SQLiteException.New(r, Errmsg16(internalDbHandle));

--- a/src/SQLite.Net.Platform.Win32/SQLiteApiWin32.cs
+++ b/src/SQLite.Net.Platform.Win32/SQLiteApiWin32.cs
@@ -79,7 +79,7 @@ namespace SQLite.Net.Platform.Win32
         {
             var internalDbHandle = (DbHandle) db;
             IntPtr stmt;
-            Result r = SQLiteApiWin32Internal.sqlite3_prepare_v2(internalDbHandle.DbPtr, query, query.Length, out stmt, IntPtr.Zero);
+            Result r = SQLiteApiWin32Internal.sqlite3_prepare_v2(internalDbHandle.DbPtr, query, -1, out stmt, IntPtr.Zero);
             if (r != Result.OK)
             {
                 throw SQLiteException.New(r, Errmsg16(internalDbHandle));

--- a/src/SQLite.Net.Platform.WinRT/SQLiteApiWinRT.cs
+++ b/src/SQLite.Net.Platform.WinRT/SQLiteApiWinRT.cs
@@ -204,7 +204,7 @@ namespace SQLite.Net.Platform.WinRT
         {
             var dbHandle = (DbHandle)db;
             var stmt = default(Sqlite3Statement);
-            var r = SQLite3.Prepare2(dbHandle.InternalDbHandle, query, query.Length, out stmt, IntPtr.Zero);
+            var r = SQLite3.Prepare2(dbHandle.InternalDbHandle, query, -1, out stmt, IntPtr.Zero);
             if (r != Result.OK)
             {
                 throw SQLiteException.New(r, SQLite3.GetErrmsg(dbHandle.InternalDbHandle));

--- a/src/SQLite.Net.Platform.XamarinAndroid/SQLiteApiAndroid.cs
+++ b/src/SQLite.Net.Platform.XamarinAndroid/SQLiteApiAndroid.cs
@@ -72,7 +72,7 @@ namespace SQLite.Net.Platform.XamarinAndroid
         {
             var internalDbHandle = (DbHandle) db;
             IntPtr stmt;
-            Result r = SQLiteApiAndroidInternal.sqlite3_prepare_v2(internalDbHandle.DbPtr, query, query.Length, out stmt, IntPtr.Zero);
+            Result r = SQLiteApiAndroidInternal.sqlite3_prepare_v2(internalDbHandle.DbPtr, query, -1, out stmt, IntPtr.Zero);
             if (r != Result.OK)
             {
                 throw SQLiteException.New(r, Errmsg16(internalDbHandle));

--- a/src/SQLite.Net.Platform.XamarinIOS.Unified/SQLiteApiIOS.cs
+++ b/src/SQLite.Net.Platform.XamarinIOS.Unified/SQLiteApiIOS.cs
@@ -72,7 +72,7 @@ namespace SQLite.Net.Platform.XamarinIOS
         {
             var internalDbHandle = (DbHandle) db;
             IntPtr stmt;
-            Result r = SQLiteApiIOSInternal.sqlite3_prepare_v2(internalDbHandle.DbPtr, query, query.Length, out stmt, IntPtr.Zero);
+            Result r = SQLiteApiIOSInternal.sqlite3_prepare_v2(internalDbHandle.DbPtr, query, -1, out stmt, IntPtr.Zero);
             if (r != Result.OK)
             {
                 throw SQLiteException.New(r, Errmsg16(internalDbHandle));

--- a/src/SQLite.Net.Platform.XamarinIOS/SQLiteApiIOS.cs
+++ b/src/SQLite.Net.Platform.XamarinIOS/SQLiteApiIOS.cs
@@ -62,7 +62,7 @@ namespace SQLite.Net.Platform.XamarinIOS {
 			IntPtr stmt;
 			Result r = SQLiteApiIOSInternal.sqlite3_prepare_v2(internalDbHandle.DbPtr,
 			                                                            query,
-			                                                            query.Length,
+			                                                            -1,
 			                                                            out stmt,
 			                                                            IntPtr.Zero);
 			if(r != Result.OK) {

--- a/tests/UnicodeTest.cs
+++ b/tests/UnicodeTest.cs
@@ -1,49 +1,66 @@
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using SQLite.Net.Attributes;
 
 namespace SQLite.Net.Tests
 {
-    [TestFixture]
-    public class UnicodeTest
-    {
-        [Test]
-        public void Insert()
-        {
-            var db = new TestDb();
+	[TestFixture]
+	public class UnicodeTest
+	{
+		[Table("\u7523\u54C1")]
+		public class UnicodeProduct
+		{
+			[AutoIncrement, PrimaryKey, Column("\u6A19\u8B58")]
+			public int Id { get; set; }
 
-            db.CreateTable<Product>();
+			[Column("\u540D")]
+			public string Name { get; set; }
 
-            string testString = "\u2329\u221E\u232A";
+			[Column("\u5024")]
+			public decimal Price { get; set; }
 
-            db.Insert(new Product
-            {
-                Name = testString,
-            });
+			[Column("\u53CE\u76CA")]
+			public uint TotalSales { get; set; }
+		}
 
-            var p = db.Get<Product>(1);
+		[Test]
+		public void Insert()
+		{
+			var db = new TestDb();
 
-            Assert.AreEqual(testString, p.Name);
-        }
+			db.CreateTable<UnicodeProduct>();
 
-        [Test]
-        public void Query()
-        {
-            var db = new TestDb();
+			string testString = "\u2329\u221E\u232A";
 
-            db.CreateTable<Product>();
+			db.Insert(new UnicodeProduct
+			{
+				Name = testString,
+			});
 
-            string testString = "\u2329\u221E\u232A";
+			var p = db.Get<UnicodeProduct>(1);
 
-            db.Insert(new Product
-            {
-                Name = testString,
-            });
+			Assert.AreEqual(testString, p.Name);
+		}
 
-            List<Product> ps = (from p in db.Table<Product>() where p.Name == testString select p).ToList();
+		[Test]
+		public void Query()
+		{
+			var db = new TestDb();
 
-            Assert.AreEqual(1, ps.Count);
-            Assert.AreEqual(testString, ps[0].Name);
-        }
-    }
+			db.CreateTable<UnicodeProduct>();
+
+			string testString = "\u2329\u221E\u232A";
+
+			db.Insert(new UnicodeProduct
+			{
+				Name = testString,
+			});
+
+			var ps = (from p in db.Table<UnicodeProduct>() where p.Name == testString select p).ToList();
+
+			Assert.AreEqual(1, ps.Count);
+			Assert.AreEqual(testString, ps[0].Name);
+		}
+	}
 }


### PR DESCRIPTION
When I use non-ascii characters for TableAttribute or ColumnAttribute, the following error was occurred.

_SQLiteException: unrecognized token: ..._

This is because the implementations of ISQLiteApi.Prepare2() miscounting length of the query.
I fixed these implementations and modified UnicodeTest.
