### PR TITLE
Allowing custom attributes to determine Primary Key, Auto Increment, etc.

### DIFF
--- a/src/SQLite.Net/Attributes/DefaultColumnInformationProvider.cs
+++ b/src/SQLite.Net/Attributes/DefaultColumnInformationProvider.cs
@@ -8,7 +8,7 @@ namespace SQLite.Net
 {
 	public class DefaultColumnInformationProvider : IColumnInformationProvider
 	{
-		#region ICustomAttributeProvider implementation
+		#region IColumnInformationProvider implementation
 
 		public IEnumerable<IndexedAttribute> GetIndices(MemberInfo p)
 		{

--- a/src/SQLite.Net/Attributes/DefaultColumnInformationProvider.cs
+++ b/src/SQLite.Net/Attributes/DefaultColumnInformationProvider.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using SQLite.Net.Attributes;
+using System.Collections.Generic;
+
+namespace SQLite.Net
+{
+	public class DefaultColumnInformationProvider : IColumnInformationProvider
+	{
+		#region ICustomAttributeProvider implementation
+
+		public IEnumerable<IndexedAttribute> GetIndices(MemberInfo p)
+		{
+			return p.GetCustomAttributes<IndexedAttribute>();
+		}
+
+		public bool IsPK(MemberInfo m)
+		{
+			return m.GetCustomAttributes<PrimaryKeyAttribute>().Any();
+		}
+
+		public string Collation(MemberInfo m)
+		{
+			foreach (var attribute in m.GetCustomAttributes<CollationAttribute>())
+			{
+				return attribute.Value;
+			}
+			return string.Empty;
+		}
+
+		public bool IsAutoInc(MemberInfo m)
+		{
+			return m.GetCustomAttributes<AutoIncrementAttribute>().Any();
+		}
+
+		public int? MaxStringLength(PropertyInfo p)
+		{
+			foreach (var attribute in p.GetCustomAttributes<MaxLengthAttribute>())
+			{
+				return attribute.Value;
+			}
+			return null;
+		}
+
+		public object GetDefaultValue(PropertyInfo p)
+		{
+			foreach (var attribute in p.GetCustomAttributes<DefaultAttribute>())
+			{
+				try
+				{
+					if (!attribute.UseProperty)
+					{
+						return Convert.ChangeType(attribute.Value, p.PropertyType);
+					}
+
+					var obj = Activator.CreateInstance(p.DeclaringType);
+					return p.GetValue(obj);
+				}
+				catch (Exception exception)
+				{
+					throw new Exception("Unable to convert " + attribute.Value + " to type " + p.PropertyType, exception);
+				}
+			}
+			return null;
+		}
+
+		public bool IsMarkedNotNull(MemberInfo p)
+		{
+			var attrs = p.GetCustomAttributes<NotNullAttribute>(true);
+			return attrs.Any();
+		}
+
+		#endregion
+	}
+}
+

--- a/src/SQLite.Net/Attributes/DefaultColumnInformationProvider.cs
+++ b/src/SQLite.Net/Attributes/DefaultColumnInformationProvider.cs
@@ -10,6 +10,17 @@ namespace SQLite.Net
 	{
 		#region IColumnInformationProvider implementation
 
+		public string GetColumnName(PropertyInfo p)
+		{
+			var colAttr = p.GetCustomAttributes<ColumnAttribute>(true).FirstOrDefault();
+			return colAttr == null ? p.Name : colAttr.Name;
+		}
+
+		public bool IsIgnored(PropertyInfo p)
+		{
+			return p.IsDefined(typeof (IgnoreAttribute), true);
+		}
+
 		public IEnumerable<IndexedAttribute> GetIndices(MemberInfo p)
 		{
 			return p.GetCustomAttributes<IndexedAttribute>();

--- a/src/SQLite.Net/Attributes/IColumnInformationProvider.cs
+++ b/src/SQLite.Net/Attributes/IColumnInformationProvider.cs
@@ -13,6 +13,8 @@ namespace SQLite.Net
 		IEnumerable<IndexedAttribute> GetIndices(MemberInfo p);
 		object GetDefaultValue(PropertyInfo p);
 		bool IsMarkedNotNull(MemberInfo p);
+		bool IsIgnored(PropertyInfo p);
+		string GetColumnName(PropertyInfo p);
 	}
 }
 

--- a/src/SQLite.Net/Attributes/IColumnInformationProvider.cs
+++ b/src/SQLite.Net/Attributes/IColumnInformationProvider.cs
@@ -1,0 +1,18 @@
+﻿using System.Reflection;
+using System.Collections.Generic;
+using SQLite.Net.Attributes;
+
+namespace SQLite.Net
+{
+	public interface IColumnInformationProvider
+	{
+		bool IsPK(MemberInfo m);
+		string Collation(MemberInfo m);
+		bool IsAutoInc(MemberInfo m);
+		int? MaxStringLength(PropertyInfo p);
+		IEnumerable<IndexedAttribute> GetIndices(MemberInfo p);
+		object GetDefaultValue(PropertyInfo p);
+		bool IsMarkedNotNull(MemberInfo p);
+	}
+}
+

--- a/src/SQLite.Net/Orm.cs
+++ b/src/SQLite.Net/Orm.cs
@@ -36,7 +36,12 @@ namespace SQLite.Net
         public const string ImplicitPkName = "Id";
         public const string ImplicitIndexSuffix = "Id";
 
-		public static IColumnInformationProvider ColumnInformationProvider { get; set; } = new DefaultColumnInformationProvider();
+		private static IColumnInformationProvider _columnInformationProvider = new DefaultColumnInformationProvider();
+		public static IColumnInformationProvider ColumnInformationProvider 
+		{
+			get { return _columnInformationProvider; }
+			set { _columnInformationProvider = value; }
+		}
 
 		internal static string SqlDecl(TableMapping.Column p, bool storeDateTimeAsTicks, IBlobSerializer serializer,
 			IDictionary<Type, string> extraTypeMappings)

--- a/src/SQLite.Net/SQLite.Net.csproj
+++ b/src/SQLite.Net/SQLite.Net.csproj
@@ -116,6 +116,8 @@
     <Compile Include="DebugTraceListener.cs" />
     <Compile Include="ISerializable.cs" />
     <Compile Include="Interop\IDbBackupHandle.cs" />
+    <Compile Include="Attributes\IColumnInformationProvider.cs" />
+    <Compile Include="Attributes\DefaultColumnInformationProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/src/SQLite.Net/SQLiteConnection.cs
+++ b/src/SQLite.Net/SQLiteConnection.cs
@@ -323,9 +323,9 @@ namespace SQLite.Net
         private TableMapping CreateAndSetMapping(Type type, CreateFlags createFlags, IDictionary<string, TableMapping> mapTable)
         {
             var props = Platform.ReflectionService.GetPublicInstanceProperties(type);
-            var map = new TableMapping(type, props, createFlags);
-	            mapTable[type.FullName] = map;
-            	return map;
+			var map = new TableMapping(type, props, createFlags, _columnInformationProvider);
+            mapTable[type.FullName] = map;
+        	return map;
         }
 
         /// <summary>

--- a/src/SQLite.Net/SQLiteConnection.cs
+++ b/src/SQLite.Net/SQLiteConnection.cs
@@ -186,6 +186,18 @@ namespace SQLite.Net
             BusyTimeout = TimeSpan.FromSeconds(0.1);
         }
 
+		private IColumnInformationProvider _columnInformationProvider;
+		[CanBeNull, PublicAPI]
+		public IColumnInformationProvider ColumnInformationProvider 
+		{
+			get { return _columnInformationProvider; }
+			set
+			{
+				_columnInformationProvider = value;
+				Orm.ColumnInformationProvider = _columnInformationProvider;
+			}
+		}
+
         [CanBeNull, PublicAPI]
         public IBlobSerializer Serializer { get; private set; }
 

--- a/src/SQLite.Net/SQLiteConnection.cs
+++ b/src/SQLite.Net/SQLiteConnection.cs
@@ -194,7 +194,7 @@ namespace SQLite.Net
 			set
 			{
 				_columnInformationProvider = value;
-				Orm.ColumnInformationProvider = _columnInformationProvider;
+				Orm.ColumnInformationProvider = _columnInformationProvider ?? new DefaultColumnInformationProvider ();
 			}
 		}
 

--- a/tests/DefaulAttributeTest.cs
+++ b/tests/DefaulAttributeTest.cs
@@ -13,7 +13,7 @@ namespace SQLite.Net.Tests
     {
         private class WithDefaultValue
         {
-
+			public const string CustomAttributeDefaultValue = "12345";
             public const int IntVal = 666;
             public static decimal DecimalVal = 666.666m;
             public static string StringVal = "Working String";
@@ -60,6 +60,80 @@ namespace SQLite.Net.Tests
 
         }
 
+		private class TestDefaultValueAttribute : Attribute
+		{
+			public string DefaultValue { get; private set; }
+
+			public TestDefaultValueAttribute(string defaultValue)
+			{
+				DefaultValue = defaultValue;
+			}
+		}
+
+		public class TestColumnInformationProvider : IColumnInformationProvider
+		{
+			public IEnumerable<IndexedAttribute> GetIndices(MemberInfo p)
+			{
+				return p.GetCustomAttributes<IndexedAttribute>();
+			}
+
+			public bool IsPK(MemberInfo m)
+			{
+				return m.GetCustomAttributes<PrimaryKeyAttribute>().Any();
+			}
+			public string Collation(MemberInfo m)
+			{
+				return string.Empty;
+			}
+			public bool IsAutoInc(MemberInfo m)
+			{
+				return false;
+			}
+			public int? MaxStringLength(PropertyInfo p)
+			{
+				return null;
+			}
+			public object GetDefaultValue(PropertyInfo p)
+			{
+				var defaultValueAttributes = p.GetCustomAttributes<TestDefaultValueAttribute> ();
+				if (!defaultValueAttributes.Any())
+				{
+					return null;
+				}
+
+				return defaultValueAttributes.First().DefaultValue;
+			}
+			public bool IsMarkedNotNull(MemberInfo p)
+			{
+				return false;
+			}
+		}
+
+		public abstract class TestObjBase<T>
+		{
+			[AutoIncrement, PrimaryKey]
+			public int Id { get; set; }
+
+			public T Data { get; set; }
+
+		}
+
+		public class TestObjIntWithDefaultValue : TestObjBase<int>
+		{
+			[TestDefaultValue("12345")]
+			public string SomeValue { get; set; }
+		}
+
+		public class TestDbWithCustomAttributes : SQLiteConnection
+		{
+			public TestDbWithCustomAttributes(String path)
+				: base(new SQLitePlatformTest(), path)
+			{
+				ColumnInformationProvider = new TestColumnInformationProvider();
+				CreateTable<TestObjIntWithDefaultValue>();
+			}
+		}
+
         [Test]
         public void TestColumnValues()
         {
@@ -96,5 +170,21 @@ namespace SQLite.Net.Tests
 
             }
         }
+
+		[Test]
+		public void TestCustomDefaultColumnValues()
+		{
+			using (var db = new TestDbWithCustomAttributes(TestPath.CreateTemporaryDatabase()))
+			{
+				string failed = string.Empty;
+				foreach (var col in db.GetMapping<TestObjIntWithDefaultValue>().Columns)
+				{
+					if (col.PropertyName == "SomeValue" && !col.DefaultValue.Equals(WithDefaultValue.CustomAttributeDefaultValue))
+						failed += " , SomeValue does not equal " + WithDefaultValue.IntVal;
+				}
+
+				Assert.True(string.IsNullOrWhiteSpace(failed), failed);
+			}
+		}
     }
 }

--- a/tests/DefaulAttributeTest.cs
+++ b/tests/DefaulAttributeTest.cs
@@ -72,6 +72,16 @@ namespace SQLite.Net.Tests
 
 		public class TestColumnInformationProvider : IColumnInformationProvider
 		{
+			public string GetColumnName(PropertyInfo p)
+			{
+				return p.Name;
+			}
+
+			public bool IsIgnored(PropertyInfo p)
+			{
+				return false;
+			}
+
 			public IEnumerable<IndexedAttribute> GetIndices(MemberInfo p)
 			{
 				return p.GetCustomAttributes<IndexedAttribute>();

--- a/tests/DefaulAttributeTest.cs
+++ b/tests/DefaulAttributeTest.cs
@@ -190,10 +190,11 @@ namespace SQLite.Net.Tests
 				foreach (var col in db.GetMapping<TestObjIntWithDefaultValue>().Columns)
 				{
 					if (col.PropertyName == "SomeValue" && !col.DefaultValue.Equals(WithDefaultValue.CustomAttributeDefaultValue))
-						failed += " , SomeValue does not equal " + WithDefaultValue.IntVal;
+						failed += " , SomeValue does not equal " + WithDefaultValue.CustomAttributeDefaultValue;
 				}
 
 				Assert.True(string.IsNullOrWhiteSpace(failed), failed);
+				db.ColumnInformationProvider = null;
 			}
 		}
     }

--- a/tests/IgnoreTest.cs
+++ b/tests/IgnoreTest.cs
@@ -2,6 +2,8 @@
 using System.Linq;
 using NUnit.Framework;
 using SQLite.Net.Attributes;
+using System;
+using System.Reflection;
 
 namespace SQLite.Net.Tests
 {
@@ -20,6 +22,68 @@ namespace SQLite.Net.Tests
             public List<string> Ignored { get; set; }
         }
 
+		private class TestIgnoreAttribute : Attribute
+		{
+		}
+
+		public class TestColumnInformationProvider : IColumnInformationProvider
+		{
+			public string GetColumnName(PropertyInfo p)
+			{
+				return p.Name;
+			}
+
+			public bool IsIgnored(PropertyInfo p)
+			{
+				return p.IsDefined(typeof (TestIgnoreAttribute), true);
+			}
+
+			public IEnumerable<IndexedAttribute> GetIndices(MemberInfo p)
+			{
+				return p.GetCustomAttributes<IndexedAttribute>();
+			}
+
+			public bool IsPK(MemberInfo m)
+			{
+				return m.GetCustomAttributes<PrimaryKeyAttribute>().Any();
+			}
+			public string Collation(MemberInfo m)
+			{
+				return string.Empty;
+			}
+			public bool IsAutoInc(MemberInfo m)
+			{
+				return false;
+			}
+			public int? MaxStringLength(PropertyInfo p)
+			{
+				return null;
+			}
+			public object GetDefaultValue(PropertyInfo p)
+			{
+				return null;
+			}
+			public bool IsMarkedNotNull(MemberInfo p)
+			{
+				return false;
+			}
+		}
+
+		public abstract class TestObjBase<T>
+		{
+			[AutoIncrement, PrimaryKey]
+			public int Id { get; set; }
+
+			public T Data { get; set; }
+
+		}
+
+		public class TestObjIntWithIgnore : TestObjBase<int>
+		{
+			[TestIgnore]
+			public List<string> Ignored { get; set; }
+		}
+
         [Test]
         public void NullableFloat()
         {
@@ -27,5 +91,14 @@ namespace SQLite.Net.Tests
             // if the Ignored property is not ignore this will cause an exception
             db.CreateTable<DummyClass>();
         }
+
+		[Test]
+		public void CustomIgnoreAttributeTest()
+		{
+			var db = new SQLiteConnection(new SQLitePlatformTest(), TestPath.CreateTemporaryDatabase());
+			db.ColumnInformationProvider = new TestColumnInformationProvider();
+			// if the Ignored property is not ignore this will cause an exception
+			db.CreateTable<TestObjIntWithIgnore>();
+		}
     }
 }

--- a/tests/IgnoreTest.cs
+++ b/tests/IgnoreTest.cs
@@ -99,6 +99,7 @@ namespace SQLite.Net.Tests
 			db.ColumnInformationProvider = new TestColumnInformationProvider();
 			// if the Ignored property is not ignore this will cause an exception
 			db.CreateTable<TestObjIntWithIgnore>();
+			db.ColumnInformationProvider = null;
 		}
     }
 }

--- a/tests/SQLite.Net.Tests.Generic/SQLite.Net.Tests.Generic.csproj
+++ b/tests/SQLite.Net.Tests.Generic/SQLite.Net.Tests.Generic.csproj
@@ -30,42 +30,34 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="PCLStorage, Version=1.0.2.0, Culture=neutral, PublicKeyToken=286fe515a2c35b64, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PCLStorage.1.0.2\lib\net45\PCLStorage.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="PCLStorage.Abstractions, Version=1.0.2.0, Culture=neutral, PublicKeyToken=286fe515a2c35b64, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PCLStorage.1.0.2\lib\net45\PCLStorage.Abstractions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Data.SQLite, Version=1.0.98.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Data.SQLite.Core.1.0.98.1\lib\net45\System.Data.SQLite.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Xml" />
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77">
+      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="PCLStorage, Version=1.0.2.0, Culture=neutral, PublicKeyToken=286fe515a2c35b64">
+      <HintPath>..\..\packages\PCLStorage.1.0.2\lib\net45\PCLStorage.dll</HintPath>
+    </Reference>
+    <Reference Include="PCLStorage.Abstractions, Version=1.0.2.0, Culture=neutral, PublicKeyToken=286fe515a2c35b64">
+      <HintPath>..\..\packages\PCLStorage.1.0.2\lib\net45\PCLStorage.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Data.SQLite, Version=1.0.98.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139">
+      <HintPath>..\..\packages\System.Data.SQLite.Core.1.0.98.1\lib\net45\System.Data.SQLite.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
These changes allow for attributes(and other logic) from outside of the library to determine whether a column is a Primary Key, Auto Incremented, Indexed, etc.

Reason: I am writing data contracts that I want to be storage agnostic, meaning that I don't want to clutter my data contracts with attributes from many different storage technologies. These could be used by anybody in my company against any data storage technology(json or xml files, SQLite, EntityFramework, etc.). We have this working for the most part for EntityFramework and other storage techs. I am currently implementing storage in our Xamarin application and there are properties I want to ignore from the SQLite database. 

For instance, let's say I have an interface and an implementation. Currently, if I wanted to ignore the EmployeeID property, I have to put in ignore attributes like below...

	public interface IDataItem
	{
		int ID { get; set; }
	}

	public class DataItem : IDataItem
	{
		public int ID { get; set; }
	}
	
	public class Employee : DataItem
	{
		[JsonIgnore]
		[XmlIgnore]
		[SQLite.Net.Ignore]
		// other "ignore" attributes from other storage providers(ie. Entity Framework, etc.)
		// since we already have ID, we don't need both columns in a database/file since they
		//   both refer to the same value
		public int EmployeeID 
		{
			get { return base.ID; }
			set { base.ID = value }
		}
	}

I want to be able to do something like this...

	public class MyIgnoreAttibute : Attribute
	{

	}

	public class Employee : DataItem
	{
		[MyIgnoreAttribute]
		public int EmployeeID { get; set; }
	}

where we can use `MyIgnoreAttribute` to ignore the column in SQLite without having to have a reference to SQLite.

This is what I have accomplished with my changes. By providing an instance of `IColumnInformationProvider`, an outside class can determine the information about the column. So for my case, my provider would look like...

	public MyColumnInfoProvider : IColumnInformationProvider
	{
		// ... other interface methods implemented
		
		public bool IsIgnored(PropertyInfo p)
		{
			return p.IsDefined(typeof (MyIgnoreAttribute), true);
		}
	}
	
	//... somewhere in my code...
	var sqlConnection = new SQLiteConnection(....);
	sqlConnection.ColumnInformationProvider = new MyColumnInfoProvider();

The changes made to the library are backwards compatible. Setting this property is not required. If an instance is not provided, an instance of the `DefaultColumnInformationProvider` class will be created and used. This default instance does exactly what the code previously did. So not giving a provider will make the library work exactly the same as before.