### PR TITLE
Added support for REPLACE-function in WHERE-clause

### DIFF
--- a/src/SQLite.Net/TableQuery.cs
+++ b/src/SQLite.Net/TableQuery.cs
@@ -432,6 +432,10 @@ namespace SQLite.Net
                 {
                     sqlCall = "(upper(" + obj.CommandText + "))";
                 }
+                else if (call.Method.Name == "Replace" && args.Length == 2)
+                {
+                    sqlCall = "(replace(" + obj.CommandText + ", " + args[0].CommandText + ", " + args[1].CommandText + "))";
+                }
                 else
                 {
                     sqlCall = call.Method.Name.ToLower() + "(" +

--- a/tests/ReplaceTest.cs
+++ b/tests/ReplaceTest.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using SQLite.Net.Attributes;
+using SQLite.Net.Interop;
+
+namespace SQLite.Net.Tests
+{
+    [TestFixture]
+    public class ReplaceTest
+    {
+        public class TestObj
+        {
+            [AutoIncrement, PrimaryKey]
+            public int Id { get; set; }
+
+            public string Name { get; set; }
+
+            public override string ToString()
+            {
+                return string.Format("[TestObj: Id={0}, Name={1}]", Id, Name);
+            }
+        }
+
+        public class TestDb : SQLiteConnection
+        {
+            public TestDb(ISQLitePlatform sqlitePlatform, string path)
+                : base(sqlitePlatform, path)
+            {
+                CreateTable<TestObj>();
+            }
+        }
+
+
+        [Test]
+
+        public void ReplaceInWhere()
+        {
+            string testElement = "Element";
+            string alternateElement = "Alternate";
+            string replacedElement = "ReplacedElement";
+
+            int n = 20;
+            IEnumerable<TestObj> cq = from i in Enumerable.Range(1, n)
+                                      select new TestObj
+                                      {
+                                          Name = (i % 2 == 0) ? testElement : alternateElement
+                                      };
+
+            var db = new TestDb(new SQLitePlatformTest(), TestPath.CreateTemporaryDatabase());
+
+            db.InsertAll(cq);
+
+            db.TraceListener = DebugTraceListener.Instance;
+
+
+            List<TestObj> result = (from o in db.Table<TestObj>() where o.Name.Replace(testElement, replacedElement) == replacedElement select o).ToList();
+            Assert.AreEqual(10, result.Count);
+
+        }
+
+    }
+}


### PR DESCRIPTION
If you currently use the .NET-String-Replace in a Where-Clause you receive an error, because this call is translated to Replace("string1", "string2") in SQLite, which is the wrong syntax. This happens because the Replace function is not handled in CompileExpr.

I've added the condition to translate the Replace-Method with the correct call in SQLite.