### PR TITLE
Update DateTime stored as strings to be output with the UTC kind

### DIFF
--- a/src/SQLite.Net/SQLiteCommand.cs
+++ b/src/SQLite.Net/SQLiteCommand.cs
@@ -473,7 +473,7 @@ namespace SQLite.Net
                 {
                     return new DateTime(_sqlitePlatform.SQLiteApi.ColumnInt64(stmt, index), DateTimeKind.Utc);
                 }
-                return DateTime.Parse(_sqlitePlatform.SQLiteApi.ColumnText16(stmt, index), CultureInfo.InvariantCulture);
+                return DateTime.Parse(_sqlitePlatform.SQLiteApi.ColumnText16(stmt, index), CultureInfo.InvariantCulture).ToUniversalTime();
             }
             if (clrType == typeof (DateTimeOffset))
             {
@@ -488,7 +488,7 @@ namespace SQLite.Net
                 }
                 else
                 {
-                    value = DateTime.Parse(_sqlitePlatform.SQLiteApi.ColumnText16(stmt, index), CultureInfo.InvariantCulture);
+                    value = DateTime.Parse(_sqlitePlatform.SQLiteApi.ColumnText16(stmt, index), CultureInfo.InvariantCulture).ToUniversalTime();
                 }
                 return Activator.CreateInstance(clrType, value);
             }

--- a/tests/DateTimeTest.cs
+++ b/tests/DateTimeTest.cs
@@ -57,6 +57,9 @@ namespace SQLite.Net.Tests
 
             Assert.AreEqual(fromDb.Time1.ToLocalTime(), org.Time1.ToLocalTime());
             Assert.AreEqual(fromDb.Time2.ToLocalTime(), org.Time2.ToLocalTime());
+
+            Assert.AreEqual(fromDb.Time1.Kind, DateTimeKind.Utc);
+            Assert.AreEqual(fromDb.Time2.Kind, DateTimeKind.Utc);
         }
 
         [Test]

--- a/tests/SerializableTest.cs
+++ b/tests/SerializableTest.cs
@@ -133,6 +133,34 @@ namespace SQLite.Net.Tests
 
             Assert.That(found.DateTimeValue.InnerValue.ToLocalTime(), Is.EqualTo(value1.ToLocalTime()));
             Assert.That(found.DateTimeValue2.InnerValue.ToLocalTime(), Is.EqualTo(value2.ToLocalTime()));
+
+            Assert.That(found.DateTimeValue.InnerValue.Kind, Is.EqualTo(DateTimeKind.Utc));
+            Assert.That(found.DateTimeValue2.InnerValue.Kind, Is.EqualTo(DateTimeKind.Utc));
+        }
+
+        [Test]
+        public void SupportsSerializableDateTimeWithStrings()
+        {
+            var dbStrings = new TestDb(storeDateTimeAsTicks: false);
+            dbStrings.CreateTable<ComplexType>();
+
+            DateTime value1 = DateTime.UtcNow;
+            DateTime value2 = DateTime.Now;
+            var model = new ComplexType
+            {
+                DateTimeValue = new SerializableDateTime(value1),
+                DateTimeValue2 = new SerializableDateTime(value2)
+            };
+            dbStrings.Insert(model);
+            ComplexType found = dbStrings.Get<ComplexType>(m => m.ID == model.ID);
+            Assert.That(found.DateTimeValue.InnerValue.ToUniversalTime(), Is.EqualTo(value1.ToUniversalTime()));
+            Assert.That(found.DateTimeValue2.InnerValue.ToUniversalTime(), Is.EqualTo(value2.ToUniversalTime()));
+
+            Assert.That(found.DateTimeValue.InnerValue.ToLocalTime(), Is.EqualTo(value1.ToLocalTime()));
+            Assert.That(found.DateTimeValue2.InnerValue.ToLocalTime(), Is.EqualTo(value2.ToLocalTime()));
+
+            Assert.That(found.DateTimeValue.InnerValue.Kind, Is.EqualTo(DateTimeKind.Utc));
+            Assert.That(found.DateTimeValue2.InnerValue.Kind, Is.EqualTo(DateTimeKind.Utc));
         }
 
         [Test]


### PR DESCRIPTION
`DateTime` types that are stored as strings should mimick the behavior of dates stored as ticks.

Currently when requesting a date from a db connection where dates are stored as strings it returns the date in local time, which is unexpected, and not congruent with the behavior when storing `DateTime` as ticks