### PR TITLE
Fix on directory ref to SQLite.Interop.dll +++ DateTimie fix

### DIFF
--- a/src/SQLite.Net.Platform.Win32/SQliteApiWin32Internal.cs
+++ b/src/SQLite.Net.Platform.Win32/SQliteApiWin32Internal.cs
@@ -34,7 +34,7 @@ namespace SQLite.Net.Platform.Win32
             if (interopPath == null)
             {
                 // no NativeInteropSearchPath given (or nothing found using this path) so load native library from assembly execution direcotry
-                string assemblyCurrentPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                string assemblyCurrentPath = AppDomain.CurrentDomain.BaseDirectory;
                 string relativePath = architectureDirectory + "\\" + interopFilename;
                 string assemblyInteropPath = Path.Combine(assemblyCurrentPath, architectureDirectory, interopFilename);
 

--- a/src/SQLite.Net/SQLiteCommand.cs
+++ b/src/SQLite.Net/SQLiteCommand.cs
@@ -471,7 +471,7 @@ namespace SQLite.Net
             {
                 if (_conn.StoreDateTimeAsTicks)
                 {
-                    return new DateTime(_sqlitePlatform.SQLiteApi.ColumnInt64(stmt, index), DateTimeKind.Utc);
+                    return new DateTime(_sqlitePlatform.SQLiteApi.ColumnInt64(stmt, index), DateTimeKind.Utc).ToLocalTime();
                 }
                 return DateTime.Parse(_sqlitePlatform.SQLiteApi.ColumnText16(stmt, index), CultureInfo.InvariantCulture);
             }
@@ -484,7 +484,7 @@ namespace SQLite.Net
                 DateTime value;
                 if (_conn.StoreDateTimeAsTicks)
                 {
-                    value = new DateTime(_sqlitePlatform.SQLiteApi.ColumnInt64(stmt, index), DateTimeKind.Utc);
+                    value = new DateTime(_sqlitePlatform.SQLiteApi.ColumnInt64(stmt, index), DateTimeKind.Utc).ToLocalTime();
                 }
                 else
                 {


### PR DESCRIPTION
Fix on wrong base directory for SQLite.Interop.dll which causes an exception, if "shadow copies" are enabled.
I experienced this issue when building an add-in for Outlook. By having shadow copies enabled ([.NET shadow copies](https://msdn.microsoft.com/de-de/library/ms404279(v=vs.110).aspx)), the SQLite.Net.Platform.Win32.dll will be copied into a shadow directory. Thus, by using `Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)`, the `LoadLibrary` tries to load interop library from a relative path, which of course does not exist in that shadow path.